### PR TITLE
Add ping plugin support

### DIFF
--- a/collectd/files/ping.conf
+++ b/collectd/files/ping.conf
@@ -1,0 +1,15 @@
+{% set hosts = hosts + salt['mine.get'](hfg.target, hfg.fun, hfg.expr_form).values() -%}
+LoadPlugin ping
+<Plugin "ping">
+  {%- for host in hosts %}
+  Host "{{ host }}"
+  {%- endfor %}
+
+
+  {{ 'Interval "{}"'.format(interval) if interval else '' }}
+  {{ 'Timeout "{}"'.format(timeout) if timeout else '' }}
+  {{ 'TTL "{}"'.format(ttl) if ttl else '' }}
+  {{ 'SourceAddress "{}"'.format(sourceaddress) if sourceaddress else '' }}
+  {{ 'Device "{}"'.format(device) if device else '' }}
+  {{ 'MaxMissed "{}"'.format(maxmissed) if maxmissed else '' }}
+</Plugin>

--- a/collectd/ping.sls
+++ b/collectd/ping.sls
@@ -1,0 +1,26 @@
+{% from "collectd/map.jinja" import collectd with context %}
+
+include:
+  - collectd.service
+
+liboping0:
+  pkg.installed
+
+{{ collectd.plugindirconfig }}/ping.conf:
+  file.managed:
+    - source: salt://collectd/files/ping.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+    - watch_in:
+      - service: collectd-service
+    - defaults:
+        hosts: {{ salt['pillar.get']('collectd:plugins:ping:hosts', ['google.com', 'yahoo.com']) }}
+        hfg: {{ salt['pillar.get']('collectd:plugins:ping:hosts_from_grains') }}
+        interval: {{ salt['pillar.get']('collectd:plugins:ping:interval') }}
+        timeout: {{ salt['pillar.get']('collectd:plugins:ping:timeout') }}
+        ttl: {{ salt['pillar.get']('collectd:plugins:ping:ttl') }}
+        sourceaddress: {{ salt['pillar.get']('collectd:plugins:ping:sourceaddress') }}
+        device: {{ salt['pillar.get']('collectd:plugins:ping:device') }}
+        maxmissed: {{ salt['pillar.get']('collectd:plugins:ping:maxmissed') }}

--- a/pillar.example
+++ b/pillar.example
@@ -45,5 +45,14 @@ collectd:
     interface:
       interfaces: ['eth0', 'lo0']
       IgnoreSelected: 'false'
+    # defaults as of 20141103
+    ping:
+      hosts: ['google.com', 'yahoo.com']
+      #interval: 1.0
+      #timeout: 0.9
+      #ttl: 64
+      #sourceaddress: 10.0.1.1
+      #device: eth0
+      #maxmissed: -1
     disk:
       matches: ['/^[hs]d[a-f][0-9]?$/']


### PR DESCRIPTION
The ping plugin is used to measure latency between hosts. Add formula support
for the plugin and example pillar config.
