### PR TITLE
Add write_graphite plugin

### DIFF
--- a/collectd/files/write_graphite.conf
+++ b/collectd/files/write_graphite.conf
@@ -1,0 +1,16 @@
+LoadPlugin write_graphite
+
+<Plugin write_graphite>
+ <Carbon>
+   Host "{{ host }}"
+   Port "{{ port }}"
+   Prefix "{{ prefix }}."
+   Postfix "{{ postfix }}"
+   Protocol "{{ protocol }}"
+   LogSendErrors {{ logsenderrors }}
+   EscapeCharacter "{{ escapecharacter }}"
+   SeparateInstances {{ separateinstances }}
+   StoreRates {{ storerates }}
+   AlwaysAppendDS {{ alwaysappendds }}
+ </Carbon>
+</Plugin>

--- a/collectd/write_graphite.sls
+++ b/collectd/write_graphite.sls
@@ -1,0 +1,26 @@
+{% from "collectd/map.jinja" import collectd with context %}
+
+include:
+  - collectd.service
+
+{{ collectd.plugindirconfig }}/write_graphite.conf:
+  file.managed:
+    - source: salt://collectd/files/write_graphite.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+    - watch_in:
+      - service: collectd-service
+    - defaults:
+        node: {{ salt['grains.get']('fqdn') }}
+        host: {{ salt['pillar.get']('collectd:plugins:write_graphite:host') }}
+        port: {{ salt['pillar.get']('collectd:plugins:write_graphite:port') }}
+        prefix: {{ salt['pillar.get']('collectd:plugins:write_graphite:prefix') }}
+        postfix: {{ salt['pillar.get']('collectd:plugins:write_graphite:postfix') }}
+        protocol: {{ salt['pillar.get']('collectd:plugins:write_graphite:protocol') }}
+        logsenderrors: {{ salt['pillar.get']('collectd:plugins:write_graphite:logsenderrors') }}
+        escapecharacter: {{ salt['pillar.get']('collectd:plugins:write_graphite:escapecharacter') }}
+        separateinstances: {{ salt['pillar.get']('collectd:plugins:write_graphite:separateinstances') }}
+        storerates: {{ salt['pillar.get']('collectd:plugins:write_graphite:storerates') }}
+        alwaysappendds: {{ salt['pillar.get']('collectd:plugins:write_graphite:alwaysappendds') }}

--- a/pillar.example
+++ b/pillar.example
@@ -47,3 +47,14 @@ collectd:
       IgnoreSelected: 'false'
     disk:
       matches: ['/^[hs]d[a-f][0-9]?$/']
+    write_graphite:
+      host: graphite-host
+      port: "2003"
+      prefix: "collectd"
+      postfix: ""
+      protocol: "tcp"
+      logsenderrors: false
+      escapecharacter: "_"
+      separateinstances: true
+      storerates: true
+      alwaysappendds: false


### PR DESCRIPTION
The write_graphite plugin allows collectd to write directly to a graphite
server. See pillar.example for configuration.
