### PR TITLE
Fix df plugin if all of Device, MountPoint, and FSType aren't set

### DIFF
--- a/collectd/files/df.conf
+++ b/collectd/files/df.conf
@@ -1,9 +1,9 @@
 LoadPlugin df
 
 <Plugin df>
-      Device "{{ Device }}"
-      MountPoint "{{ MountPoint }}"
-      FSType "{{ FSType }}"
+      {{ 'Device "{}"'.format(Device) if Device else '' }}
+      {{ 'MountPoint "{}"'.format(MountPoint) if MountPoint else '' }}
+      {{ 'FSType "{}"'.format(FSType) if FSType else '' }}
       IgnoreSelected {{ IgnoreSelected }}
       ReportByDevice {{ ReportByDevice }}
       ReportReserved {{ ReportReserved }}


### PR DESCRIPTION
The df plugin can work with just one of Device, MountPoint, and FSType set.
It will not however function with "None" in any of those fields, so just fix
it to output an empty string if there is no pillar value set.
