### PR TITLE
Fix includes so states can be run independently

### DIFF
--- a/collectd/apache.sls
+++ b/collectd/apache.sls
@@ -1,7 +1,7 @@
 {% from "collectd/map.jinja" import collectd with context %}
 
 include:
-  - collectd.service
+  - collectd
 
 {{ collectd.plugindirconfig }}/apache.conf:
   file.managed:

--- a/collectd/df.sls
+++ b/collectd/df.sls
@@ -1,7 +1,7 @@
 {% from "collectd/map.jinja" import collectd with context %}
 
 include:
-  - collectd.service
+  - collectd
 
 {{ collectd.plugindirconfig }}/df.conf:
   file.managed:

--- a/collectd/disk.sls
+++ b/collectd/disk.sls
@@ -1,7 +1,7 @@
 {% from "collectd/map.jinja" import collectd with context %}
 
 include:
-  - collectd.service
+  - collectd
 
 {{ collectd.plugindirconfig }}/disk.conf:
   file.managed:

--- a/collectd/ethstat.sls
+++ b/collectd/ethstat.sls
@@ -1,7 +1,7 @@
 {% from "collectd/map.jinja" import collectd with context %}
 
 include:
-  - collectd.service
+  - collectd
 
 {{ collectd.plugindirconfig }}/ethstat.conf:
   file.managed:

--- a/collectd/interface.sls
+++ b/collectd/interface.sls
@@ -1,7 +1,7 @@
 {% from "collectd/map.jinja" import collectd with context %}
 
 include:
-  - collectd.service
+  - collectd
 
 {{ collectd.plugindirconfig }}/interface.conf:
   file.managed:

--- a/collectd/java.sls
+++ b/collectd/java.sls
@@ -1,7 +1,7 @@
 {% from "collectd/map.jinja" import collectd with context %}
 
 include:
-  - collectd.service
+  - collectd
 
 collectd-java:
     file.rename:

--- a/collectd/mysql.sls
+++ b/collectd/mysql.sls
@@ -1,7 +1,7 @@
 {% from "collectd/map.jinja" import collectd with context %}
 
 include:
-  - collectd.service
+  - collectd
 
 {{ collectd.plugindirconfig }}/mysql.conf:
   file.managed:

--- a/collectd/network.sls
+++ b/collectd/network.sls
@@ -1,7 +1,7 @@
 {% from "collectd/map.jinja" import collectd with context %}
 
 include:
-  - collectd.service
+  - collectd
 
 {{ collectd.plugindirconfig }}/network.conf:
   file.managed:

--- a/collectd/ntpd.sls
+++ b/collectd/ntpd.sls
@@ -1,7 +1,7 @@
 {% from "collectd/map.jinja" import collectd with context %}
 
 include:
-  - collectd.service
+  - collectd
 
 {{ collectd.plugindirconfig }}/ntpd.conf:
   file.managed:

--- a/collectd/ping.sls
+++ b/collectd/ping.sls
@@ -1,7 +1,7 @@
 {% from "collectd/map.jinja" import collectd with context %}
 
 include:
-  - collectd.service
+  - collectd
 
 liboping0:
   pkg.installed

--- a/collectd/postgresql.sls
+++ b/collectd/postgresql.sls
@@ -1,7 +1,7 @@
 {% from "collectd/map.jinja" import collectd with context %}
 
 include:
-  - collectd.service
+  - collectd
 
 {{ collectd.plugindirconfig }}/postgresql.conf:
   file.managed:

--- a/collectd/syslog.sls
+++ b/collectd/syslog.sls
@@ -1,7 +1,7 @@
 {% from "collectd/map.jinja" import collectd with context %}
 
 include:
-  - collectd.service
+  - collectd
 
 {{ collectd.plugindirconfig }}/syslog.conf:
   file.managed:

--- a/collectd/write_graphite.sls
+++ b/collectd/write_graphite.sls
@@ -1,7 +1,7 @@
 {% from "collectd/map.jinja" import collectd with context %}
 
 include:
-  - collectd.service
+  - collectd
 
 {{ collectd.plugindirconfig }}/write_graphite.conf:
   file.managed:


### PR DESCRIPTION
If you try to run collectd.df (or any other state) individually, it fails
because it includes the service state file, but the service requires the
package state. We can't just include the package state in the service state
because it would cause a circular dependency.
