### PR TITLE
Fix ping plugin for unset host_from_grains in pillar

### DIFF
--- a/collectd/files/ping.conf
+++ b/collectd/files/ping.conf
@@ -1,4 +1,6 @@
+{% if hfg -%}
 {% set hosts = hosts + salt['mine.get'](hfg.target, hfg.fun, hfg.expr_form).values() -%}
+{% endif -%}
 LoadPlugin ping
 <Plugin "ping">
   {%- for host in hosts %}


### PR DESCRIPTION
If the host_from_grains pillar isn't set, you get a jinja error about an
undefined variable in the ping plugin.
