### PR TITLE
adds support for write_riemann plugin

### DIFF
--- a/collectd/files/write_riemann.conf
+++ b/collectd/files/write_riemann.conf
@@ -1,0 +1,12 @@
+LoadPlugin write_riemann
+
+<Plugin "write_riemann">
+ <Node "{{ node }}">
+   Host "{{ host }}"
+   Port "{{ port }}"
+   Protocol {{ protocol }}
+   StoreRates {{ storerates|string|lower }}
+   AlwaysAppendDS {{ alwaysappendds|string|lower }}
+ </Node>
+ Tag "{{ tag }}"
+</Plugin>

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -1,6 +1,6 @@
 {% set collectd = salt['grains.filter_by']({
     'Debian': {
-        'pkg': 'collectd-core',
+        'pkg': 'collectd',
         'service': 'collectd',
         'config': '/etc/collectd/collectd.conf',
         'plugindirconfig': '/etc/collectd/plugins',

--- a/collectd/write_riemann.sls
+++ b/collectd/write_riemann.sls
@@ -1,0 +1,22 @@
+{% from "collectd/map.jinja" import collectd with context %}
+
+include:
+  - collectd
+
+{{ collectd.plugindirconfig }}/write_riemann.conf:
+  file.managed:
+    - source: salt://collectd/files/write_riemann.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+    - watch_in:
+      - service: collectd-service
+    - defaults:
+        node: {{ salt['grains.get']('fqdn') }}
+        host: {{ salt['pillar.get']('collectd:plugins:write_riemann:host') }}
+        port: {{ salt['pillar.get']('collectd:plugins:write_riemann:port') }}
+        protocol: {{ salt['pillar.get']('collectd:plugins:write_riemann:protocol') }}
+        storerates: {{ salt['pillar.get']('collectd:plugins:write_riemann:storerates') }}
+        alwaysappendds: {{ salt['pillar.get']('collectd:plugins:write_riemann:alwaysappendds') }}
+        tag: {{ salt['pillar.get']('collectd:plugins:write_riemann:tag') }}

--- a/pillar.example
+++ b/pillar.example
@@ -67,3 +67,10 @@ collectd:
       separateinstances: true
       storerates: true
       alwaysappendds: false
+    write_riemann:
+      host: "riemann-host"
+      port: "5555"
+      protocol: TCP
+      storerates: "true"
+      alwaysappendds: "false"
+      tag: "sometag"


### PR DESCRIPTION
With this PR a new salt state is introduced: `collectd.write_riemann`. This requires a recent version of collectd package (>= 5.3), which is available in Ubuntu 14.04, Debian Jessie and RedHat 7.

As the `collectd-core` package does not (at least for Ubuntu) include the needed protobuf-c.h files (see Dependencies in https://collectd.org/wiki/index.php/Plugin:Write_Riemann), the required package is now the meta package `collectd`.