### PR TITLE
adds map entry for RedHat based OS

### DIFF
--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -6,4 +6,10 @@
         'plugindirconfig': '/etc/collectd/plugins',
         'javalib': '/usr/lib/collectd/java.so',
     },
+    'RedHat': {
+        'pkg': 'collectd',
+        'service': 'collectd',
+        'config': '/etc/collectd.conf',
+        'plugindirconfig': '/etc/collectd.d',
+    },
 }, merge=salt['pillar.get']('collectd:lookup')) %}


### PR DESCRIPTION
Adds map.jinja entry for RedHat based OS.

Tested on CentOS 6.5 and 7.0.
