### PR TITLE
Add require on liboping package

### DIFF
--- a/collectd/ping.sls
+++ b/collectd/ping.sls
@@ -13,6 +13,8 @@ liboping0:
     - group: root
     - mode: 644
     - template: jinja
+    - require:
+      - pkg: liboping0
     - watch_in:
       - service: collectd-service
     - defaults:


### PR DESCRIPTION
For some reason, the service is getting restarted before the package is
installed (but after the config file is in place). So collectd tries and fails
to enable the ping plugin (without having the lib in place already).
