### PR TITLE
Sanity check that the user has mine setup correctly

### DIFF
--- a/collectd/files/ping.conf
+++ b/collectd/files/ping.conf
@@ -1,4 +1,4 @@
-{% if hfg -%}
+{% if hfg and salt['mine.get'](hfg.target, hfg.fun, hfg.expr_form) -%}
 {% set hosts = hosts + salt['mine.get'](hfg.target, hfg.fun, hfg.expr_form).values() -%}
 {% endif -%}
 LoadPlugin ping


### PR DESCRIPTION
The original test only caught one failure case. If they configured the formula
to pull hosts from grain data, but they don't have the grains/mine/etc setup
correctly, the formula fails.
