### PR TITLE
Fix double Quotes missing

### DIFF
--- a/collectd/files/ethstat.conf
+++ b/collectd/files/ethstat.conf
@@ -2,7 +2,7 @@ LoadPlugin ethstat
 
 <Plugin "ethstat">
   Interface "{{ interface }}"
-  Map "rx_csum_offload_errors" "if_rx_errors" checksum_offload"
+  Map "rx_csum_offload_errors" "if_rx_errors" "checksum_offload"
   Map "multicast" "if_multicast"
   MappedOnly false
 </Plugin>


### PR DESCRIPTION
In syslog : "collectd: ethstat plugin: The Map option requires two or three string arguments."
