### PR TITLE
Ensure 'default' is defined in collectd config

### DIFF
--- a/collectd/init.sls
+++ b/collectd/init.sls
@@ -30,6 +30,6 @@ collectd:
         hostname: {{ salt['grains.get']('fqdn') }}
         FQDNLookup: {{ salt['pillar.get']('collectd:FQDNLookup', 'false') }}
         types: {{ salt['pillar.get']('collectd:TypesDB', ['/usr/share/collectd/types.db']) }}
-        default: {{ salt['pillar.get']('collectd:plugins:default') }}
+        default: {{ salt['pillar.get']('collectd:plugins:default', ['battery', 'cpu', 'entropy', 'load', 'memory', 'swap', 'users']) }}
         plugindirconfig: {{ collectd.plugindirconfig }}
         plugins: {{ salt['pillar.get']('collectd:plugins:enable', false) }}


### PR DESCRIPTION
This patch ensures that 'default' is defined even if the user of this formula has not yet provided a pillar. Previously this caused the ``{{ collectd.config }}`` state to fail with:

```
----------
          ID: /etc/collectd/collectd.conf
    Function: file.managed
      Result: False
     Comment: Unable to manage file: Jinja error: 'NoneType' object is not iterable
              Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/utils/templates.py", line 286, in render_jinja_tmpl
                  output = template.render(**unicode_context)
                File "/usr/lib/python2.7/dist-packages/jinja2/environment.py", line 894, in render
                  return self.environment.handle_exception(exc_info, True)
                File "<template>", line 10, in top-level template code
              TypeError: 'NoneType' object is not iterable
              
              ; line 10
              
              ---
              [...]
              TypesDB {% for type in types %} "{{ type }}" {% endfor %}
              #Interval 10
              #Timeout 2
              #ReadThreads 5
              
              {% for plugin in default %}    <======================
              LoadPlugin {{ plugin }}
              {% endfor %}
              
              {% if plugins %}
              Include "{{ plugindirconfig }}/*.conf"
              [...]
              ---
```