### PR TITLE
Switch to standard formula style

### DIFF
--- a/collectd/apache.sls
+++ b/collectd/apache.sls
@@ -1,9 +1,9 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
 
-{{ collectd.plugindirconfig }}/apache.conf:
+{{ collectd_settings.plugindirconfig }}/apache.conf:
   file.managed:
     - source: salt://collectd/files/apache.conf
     - user: root
@@ -12,5 +12,3 @@ include:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        host: {{ salt['grains.get']('host') }}

--- a/collectd/df.sls
+++ b/collectd/df.sls
@@ -1,9 +1,9 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
 
-{{ collectd.plugindirconfig }}/df.conf:
+{{ collectd_settings.plugindirconfig }}/df.conf:
   file.managed:
     - source: salt://collectd/files/df.conf
     - user: root
@@ -12,11 +12,3 @@ include:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        Device: {{ salt['pillar.get']('collectd:plugins:df:Device') }}
-        MountPoint: {{ salt['pillar.get']('collectd:plugins:df:MountPoint') }}
-        FSType: {{ salt['pillar.get']('collectd:plugins:df:FSType') }}
-        IgnoreSelected: {{ salt['pillar.get']('collectd:plugins:df:IgnoreSelected', 'false') }}
-        ReportByDevice: {{ salt['pillar.get']('collectd:plugins:df:ReportByDevice', 'false') }}
-        ReportReserved: {{ salt['pillar.get']('collectd:plugins:df:ReportReserved', 'false') }}
-        ReportInodes: {{ salt['pillar.get']('collectd:plugins:df:ReportInodes', 'false') }}

--- a/collectd/disk.sls
+++ b/collectd/disk.sls
@@ -1,9 +1,9 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
 
-{{ collectd.plugindirconfig }}/disk.conf:
+{{ collectd_settings.plugindirconfig }}/disk.conf:
   file.managed:
     - source: salt://collectd/files/disk.conf
     - user: root
@@ -12,5 +12,3 @@ include:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        matches: {{ salt['pillar.get']('collectd:plugins:disk:matches', []) }}

--- a/collectd/ethstat.sls
+++ b/collectd/ethstat.sls
@@ -1,9 +1,9 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
 
-{{ collectd.plugindirconfig }}/ethstat.conf:
+{{ collectd_settings.plugindirconfig }}/ethstat.conf:
   file.managed:
     - source: salt://collectd/files/ethstat.conf
     - user: root
@@ -12,6 +12,3 @@ include:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        interface: {{ salt['pillar.get']('collectd:plugins:ethstat:interface', 'eth0') }}
-

--- a/collectd/files/apache.conf
+++ b/collectd/files/apache.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin apache
 
 <Plugin apache>

--- a/collectd/files/apache.conf
+++ b/collectd/files/apache.conf
@@ -1,7 +1,9 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin apache
 
 <Plugin apache>
-        <Instance "{{ host }}">
+        <Instance "{{ collectd_settings.plugins.apache.host }}">
                 URL "http://localhost/server-status?auto"
 #               User "www-user"
 #               Password "secret"

--- a/collectd/files/collectd.conf
+++ b/collectd/files/collectd.conf
@@ -1,4 +1,11 @@
-{%- from "collectd/map.jinja" import collectd_settings with context %}
+{%- from "collectd/map.jinja" import collectd_settings with context -%}
+
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
 
 Hostname "{{ salt['grains.get']('fqdn') }}"
 FQDNLookup {{ collectd_settings.FQDNLookup }}

--- a/collectd/files/collectd.conf
+++ b/collectd/files/collectd.conf
@@ -1,16 +1,21 @@
-Hostname "{{ hostname }}"
-FQDNLookup true
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
+Hostname "{{ salt['grains.get']('fqdn') }}"
+FQDNLookup {{ collectd_settings.FQDNLookup }}
 #BaseDir "/var/lib/collectd"
 #PluginDir "/usr/lib/collectd"
-TypesDB {% for type in types %} "{{ type }}" {% endfor %}
+
+{% for type in collectd_settings.TypesDB %}
+TypesDB "{{ type }}"
+{%- endfor %}
 #Interval 10
 #Timeout 2
 #ReadThreads 5
 
-{% for plugin in default %}
+{% for plugin in collectd_settings.default_plugins %}
 LoadPlugin {{ plugin }}
-{% endfor %}
+{%- endfor %}
 
-{% if plugins %}
-Include "{{ plugindirconfig }}/*.conf"
-{% endif %}
+{% if collectd_settings.plugins.enable %}
+Include "{{ collectd_settings.plugindirconfig }}/*.conf"
+{% endif -%}

--- a/collectd/files/df.conf
+++ b/collectd/files/df.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin df
 
 <Plugin df>

--- a/collectd/files/df.conf
+++ b/collectd/files/df.conf
@@ -1,11 +1,19 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin df
 
 <Plugin df>
-      {{ 'Device "{}"'.format(Device) if Device else '' }}
-      {{ 'MountPoint "{}"'.format(MountPoint) if MountPoint else '' }}
-      {{ 'FSType "{}"'.format(FSType) if FSType else '' }}
-      IgnoreSelected {{ IgnoreSelected }}
-      ReportByDevice {{ ReportByDevice }}
-      ReportReserved {{ ReportReserved }}
-      ReportInodes {{ ReportInodes }}
+{%- if collectd_settings.plugins.df.Device is defined and collectd_settings.plugins.df.Device %}
+      Device "{{ collectd_settings.plugins.df.Device }}"
+{%- endif %}
+{%- if collectd_settings.plugins.df.MountPoint is defined and collectd_settings.plugins.df.MountPoint %}
+      MountPoint "{{ collectd_settings.plugins.df.MountPoint }}"
+{%- endif %}
+{%- if collectd_settings.plugins.df.FSType is defined and collectd_settings.plugins.df.FSType %}
+      FSType "{{ collectd_settings.plugins.df.FSType }}"
+{%- endif %}
+      IgnoreSelected "{{ collectd_settings.plugins.df.IgnoreSelected }}"
+      ReportByDevice "{{ collectd_settings.plugins.df.ReportByDevice }}"
+      ReportReserved "{{ collectd_settings.plugins.df.ReportReserved }}"
+      ReportInodes "{{ collectd_settings.plugins.df.ReportInodes }}"
 </Plugin>

--- a/collectd/files/disk.conf
+++ b/collectd/files/disk.conf
@@ -1,9 +1,9 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin disk
 
 <Plugin disk>
-{% if matches %}
-{% for match in matches %}
+{%- for match in collectd_settings.plugins.disk.matches %}
         Disk "{{ match}}"
-{% endfor %}
-{% endif %}
+{%- endfor %}
 </Plugin>

--- a/collectd/files/disk.conf
+++ b/collectd/files/disk.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin disk
 
 <Plugin disk>

--- a/collectd/files/ethstat.conf
+++ b/collectd/files/ethstat.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin ethstat
 
 <Plugin "ethstat">

--- a/collectd/files/ethstat.conf
+++ b/collectd/files/ethstat.conf
@@ -1,7 +1,9 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin ethstat
 
 <Plugin "ethstat">
-  Interface "{{ interface }}"
+  Interface "{{ collectd_settings.plugins.ethstat.interface }}"
   Map "rx_csum_offload_errors" "if_rx_errors" "checksum_offload"
   Map "multicast" "if_multicast"
   MappedOnly false

--- a/collectd/files/interface.conf
+++ b/collectd/files/interface.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin interface
 
 <Plugin "interface">

--- a/collectd/files/interface.conf
+++ b/collectd/files/interface.conf
@@ -1,8 +1,10 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin interface
 
 <Plugin "interface">
-{% for interface in interfaces %}
-    Interface "{{ interface }}"
-{% endfor %}
-  IgnoreSelected {{ IgnoreSelected }}
+{%- for interface in collectd_settings.plugins.interface.interfaces %}
+  Interface "{{ interface }}"
+{%- endfor %}
+  IgnoreSelected {{ collectd_settings.plugins.interface.IgnoreSelected }}
 </Plugin>

--- a/collectd/files/java.conf
+++ b/collectd/files/java.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin java
 
 <Plugin "java">

--- a/collectd/files/java.conf
+++ b/collectd/files/java.conf
@@ -1,3 +1,5 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin java
 
 <Plugin "java">
@@ -210,12 +212,14 @@ LoadPlugin java
     # Connection blocks #
     #####################
     <Connection>
-      ServiceURL "service:jmx:rmi:///jndi/rmi://{{ host }}:{{ port }}/jmxrmi"
-      {% if user %}
+      ServiceURL "service:jmx:rmi:///jndi/rmi://{{ collectd_settings.plugins.java.host }}:{{ collectd_settings.plugins.java.port }}/jmxrmi"
+{%- if collectd_settings.plugins.java.user is defined and collectd_settings.plugins.java.user %}
       User "{{ user }}"
+{%- endif %}
+{%- if collectd_settings.plugins.java.password is defined and collectd_settings.plugins.java.password %}
       Password "{{ pass }}"
-      {% endif %}
-      Host "{{ host }}"
+{%- endif %}
+      Host "{{ collectd_settings.plugins.java.host }}"
       Collect "classes"
       Collect "compilation"
       Collect "garbage_collector"

--- a/collectd/files/mysql.conf
+++ b/collectd/files/mysql.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin mysql
 
 <Plugin mysql>

--- a/collectd/files/mysql.conf
+++ b/collectd/files/mysql.conf
@@ -1,22 +1,27 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin mysql
 
 <Plugin mysql>
 
-{% for db in databases %}
+{% for db in collectd_settings.plugins.mysql.databases %}
       <Database db.name>
               Host "{{ db.host }}"
+{%- if db.port is defined and db.port %}
               Port "{{ db.port }}"
+{%- endif %}
+{%- if db.user is defined and db.user %}
               User "{{ db.user }}"
+{%- endif %}
+{%- if db.pass is defined and db.pass %}
               Password "{{ db.pass }}"
+{%- endif %}
+{%- if db.name is defined and db.name %}
               Database "{{ db.name }}"
+{%- endif %}
+{%- if db.masterstats is defined and db.masterstats %}
               MasterStats true
+{%- endif %}
       </Database>
-{% endfor %}
-
-      # <Database db_name2>
-      #         Host "localhost"
-      #         Socket "/var/run/mysql/mysqld.sock"
-      #         SlaveStats true
-      #         SlaveNotifications true
-      # </Database>
+{%- endfor %}
 </Plugin>

--- a/collectd/files/network.conf
+++ b/collectd/files/network.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin network
 
 <Plugin network>

--- a/collectd/files/network.conf
+++ b/collectd/files/network.conf
@@ -1,8 +1,10 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin network
 
 <Plugin network>
 #       # client setup:
-      Server "{{ host }}" "{{ port }}"
+      Server "{{ collectd_settings.plugins.network.host }}" "{{ collectd_settings.plugins.network.port }}"
 #       <Server "239.192.74.66" "25826">
 #               SecurityLevel Encrypt
 #               Username "user"

--- a/collectd/files/nginx.conf
+++ b/collectd/files/nginx.conf
@@ -1,9 +1,22 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin nginx
+
 <Plugin "nginx">
-  {{ 'URL "{}"'.format(url) if url else '' }}
-  {{ 'User "{}"'.format(user) if user else '' }}
-  {{ 'Password "{}"'.format(password) if password else '' }}
-  {{ 'VerifyPeer "{}"'.format(verifypeer) if verifypeer else '' }}
-  {{ 'VerifyHost "{}"'.format(verifyhost) if verifyhost else '' }}
-  {{ 'CACert "{}"'.format(cacert) if cacert else '' }}
+  URL "{{ collectd_settings.plugins.nginx.url }}"
+{%- if collectd_settings.plugins.nginx.user is defined and collectd_settings.plugins.nginx.user %}
+  User "{{ collectd_settings.plugins.nginx.user }}"
+{%- endif %}
+{%- if collectd_settings.plugins.nginx.password is defined and collectd_settings.plugins.nginx.password %}
+  Password "{{ collectd_settings.plugins.nginx.password }}"
+{%- endif %}
+{%- if collectd_settings.plugins.nginx.verifypeer is defined and collectd_settings.plugins.nginx.verifypeer %}
+  VerifyPeer "{{ collectd_settings.plugins.nginx.verifypeer }}"
+{%- endif %}
+{%- if collectd_settings.plugins.nginx.verifyhost is defined and collectd_settings.plugins.nginx.verifyhost %}
+  VerifyHost "{{ collectd_settings.plugins.nginx.verifyhost }}"
+{%- endif %}
+{%- if collectd_settings.plugins.nginx.cacert is defined and collectd_settings.plugins.nginx.cacert %}
+  CACert "{{ collectd_settings.plugins.nginx.cacert }}"
+{%- endif %}
 </Plugin>

--- a/collectd/files/nginx.conf
+++ b/collectd/files/nginx.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin nginx
 
 <Plugin "nginx">

--- a/collectd/files/ntpd.conf
+++ b/collectd/files/ntpd.conf
@@ -1,7 +1,9 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin ntpd
 
 <Plugin "ntpd">
-  Host "{{ host }}"
-  Port "{{ port }}"
-  ReverseLookups {{ ReverseLookups }}
+  Host "{{ collectd_settings.plugins.ntpd.host }}"
+  Port "{{ collectd_settings.plugins.ntpd.port }}"
+  ReverseLookups {{ collectd_settings.plugins.ntpd.ReverseLookups }}
 </Plugin>

--- a/collectd/files/ntpd.conf
+++ b/collectd/files/ntpd.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin ntpd
 
 <Plugin "ntpd">

--- a/collectd/files/ping.conf
+++ b/collectd/files/ping.conf
@@ -1,17 +1,34 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
+{%- set hfg = ping_settings.hosts_from_grains %}
+
 {% if hfg and salt['mine.get'](hfg.target, hfg.fun, hfg.expr_form) -%}
 {% set hosts = hosts + salt['mine.get'](hfg.target, hfg.fun, hfg.expr_form).values() -%}
 {% endif -%}
+
 LoadPlugin ping
+
 <Plugin "ping">
-  {%- for host in hosts %}
+{%- for host in hosts %}
   Host "{{ host }}"
-  {%- endfor %}
+{%- endfor %}
 
-
-  {{ 'Interval "{}"'.format(interval) if interval else '' }}
-  {{ 'Timeout "{}"'.format(timeout) if timeout else '' }}
-  {{ 'TTL "{}"'.format(ttl) if ttl else '' }}
-  {{ 'SourceAddress "{}"'.format(sourceaddress) if sourceaddress else '' }}
-  {{ 'Device "{}"'.format(device) if device else '' }}
-  {{ 'MaxMissed "{}"'.format(maxmissed) if maxmissed else '' }}
+{%- if collectd_settings.plugins.df.Device is defined and collectd_settings.plugins.df.Device %}
+  Interval "{{ collectd_settings.plugins.ping.interval }}"
+{%- endif %}
+{%- if collectd_settings.plugins.df.Device is defined and collectd_settings.plugins.df.Device %}
+  Timeout "{{ collectd_settings.plugins.ping.timeout }}"
+{%- endif %}
+{%- if collectd_settings.plugins.df.Device is defined and collectd_settings.plugins.df.Device %}
+  TTL "{{ collectd_settings.plugins.ping.ttl }}"
+{%- endif %}
+{%- if collectd_settings.plugins.df.Device is defined and collectd_settings.plugins.df.Device %}
+  SourceAddress "{{ collectd_settings.plugins.ping.sourceaddress }}"
+{%- endif %}
+{%- if collectd_settings.plugins.df.Device is defined and collectd_settings.plugins.df.Device %}
+  Device "{{ collectd_settings.plugins.ping.device }}"
+{%- endif %}
+{%- if collectd_settings.plugins.df.Device is defined and collectd_settings.plugins.df.Device %}
+  MaxMissed "{{ collectd_settings.plugins.ping.maxmissed }}"
+{%- endif %}
 </Plugin>

--- a/collectd/files/ping.conf
+++ b/collectd/files/ping.conf
@@ -6,6 +6,13 @@
 {% set hosts = hosts + salt['mine.get'](hfg.target, hfg.fun, hfg.expr_form).values() -%}
 {% endif -%}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin ping
 
 <Plugin "ping">

--- a/collectd/files/postgresql.conf
+++ b/collectd/files/postgresql.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin postgresql
 
 <Plugin postgresql>

--- a/collectd/files/postgresql.conf
+++ b/collectd/files/postgresql.conf
@@ -1,35 +1,9 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin postgresql
 
-
 <Plugin postgresql>
-      # <Query magic>
-      #         Statement "SELECT magic FROM wizard WHERE host = $1;"
-      #         Param hostname
-
-      #         <Result>
-      #                 Type gauge
-      #                 InstancePrefix "magic"
-      #                 ValuesFrom "magic"
-      #         </Result>
-      # </Query>
-
-      # <Query rt36_tickets>
-      #         Statement "SELECT COUNT(type) AS count, type \
-      #                           FROM (SELECT CASE \
-      #                                        WHEN resolved = 'epoch' THEN 'open' \
-      #                                        ELSE 'resolved' END AS type \
-      #                                        FROM tickets) type \
-      #                           GROUP BY type;"
-
-      #         <Result>
-      #                 Type counter
-      #                 InstancePrefix "rt36_tickets"
-      #                 InstancesFrom "type"
-      #                 ValuesFrom "count"
-      #         </Result>
-      # </Query>
-
-{% for db in databases %}
+{%- for db in collectd_settings.plugins.postgresql.databases %}
       <Database {{ db.name }}>
               Host "{{ db.host }}"
               Port "{{ db.port }}"
@@ -41,12 +15,5 @@ LoadPlugin postgresql
 
               # Query magic
       </Database>
-{% endfor %}
-      # <Database bar>
-      #         Interval 60
-      #         Service "service_name"
-
-      #         Query backend # predefined
-      #         Query rt36_tickets
-      # </Database>
+{%- endfor %}
 </Plugin>

--- a/collectd/files/processes.conf
+++ b/collectd/files/processes.conf
@@ -1,10 +1,12 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin processes
 
 <Plugin "processes">
-{% for proc in Processes %}
+{% for proc in collectd_settings.plugins.processes.Processes %}
 Process {{ proc }}
 {% endfor %}
-{% for procm in ProcessMatches %}
+{% for procm in collectd_settings.plugins.processes.ProcessMatches %}
 ProcessMatch {{ procm }}
 {% endfor %}
 </Plugin>

--- a/collectd/files/processes.conf
+++ b/collectd/files/processes.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin processes
 
 <Plugin "processes">

--- a/collectd/files/statsd.conf
+++ b/collectd/files/statsd.conf
@@ -1,6 +1,8 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin statsd
 
 <Plugin statsd>
-  Host "{{ Host }}"
-  Port {{ Port }}
+  Host "{{ collectd_settings.plugins.statsd.host }}"
+  Port {{ collectd_settings.plugins.statsd.port }}
 </Plugin>

--- a/collectd/files/statsd.conf
+++ b/collectd/files/statsd.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin statsd
 
 <Plugin statsd>

--- a/collectd/files/syslog.conf
+++ b/collectd/files/syslog.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin syslog
 
 <Plugin syslog>

--- a/collectd/files/syslog.conf
+++ b/collectd/files/syslog.conf
@@ -1,5 +1,7 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin syslog
 
 <Plugin syslog>
-        LogLevel info
+        LogLevel {{ collectd_settings.plugins.syslog.loglevel }}
 </Plugin>

--- a/collectd/files/write_graphite.conf
+++ b/collectd/files/write_graphite.conf
@@ -1,5 +1,12 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
 LoadPlugin write_graphite
 
 <Plugin write_graphite>

--- a/collectd/files/write_graphite.conf
+++ b/collectd/files/write_graphite.conf
@@ -1,16 +1,18 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
 LoadPlugin write_graphite
 
 <Plugin write_graphite>
  <Carbon>
-   Host "{{ host }}"
-   Port "{{ port }}"
-   Prefix "{{ prefix }}."
-   Postfix "{{ postfix }}"
-   Protocol "{{ protocol }}"
-   EscapeCharacter "{{ escapecharacter }}"
-   LogSendErrors {{ logsenderrors|lower }}
-   SeparateInstances {{ separateinstances|lower }}
-   StoreRates {{ storerates|lower }}
-   AlwaysAppendDS {{ alwaysappendds|lower }}
+   Host "{{ collectd_settings.plugins.write_graphite.host }}"
+   Port "{{ collectd_settings.plugins.write_graphite.port }}"
+   Prefix "{{ collectd_settings.plugins.write_graphite.prefix }}."
+   Postfix "{{ collectd_settings.plugins.write_graphite.postfix }}"
+   Protocol "{{ collectd_settings.plugins.write_graphite.protocol }}"
+   EscapeCharacter "{{ collectd_settings.plugins.write_graphite.escapecharacter }}"
+   LogSendErrors {{ collectd_settings.plugins.write_graphite.logsenderrors|lower }}
+   SeparateInstances {{ collectd_settings.plugins.write_graphite.separateinstances|lower }}
+   StoreRates {{ collectd_settings.plugins.write_graphite.storerates|lower }}
+   AlwaysAppendDS {{ collectd_settings.plugins.write_graphite.alwaysappendds|lower }}
  </Carbon>
 </Plugin>

--- a/collectd/init.sls
+++ b/collectd/init.sls
@@ -1,13 +1,13 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd.service
 
 collectd:
   pkg.installed:
-    - name: {{ collectd.pkg }}
+    - name: {{ collectd_settings.pkg }}
 
-{{ collectd.plugindirconfig }}:
+{{ collectd_settings.plugindirconfig }}:
   file.directory:
     - user: root
     - group: root
@@ -17,7 +17,7 @@ collectd:
     - require_in:
       - service: collectd-service # set proper file mode before service runs
 
-{{ collectd.config }}:
+{{ collectd_settings.config }}:
   file.managed:
     - source: salt://collectd/files/collectd.conf
     - user: root
@@ -26,10 +26,3 @@ collectd:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        hostname: {{ salt['grains.get']('fqdn') }}
-        FQDNLookup: {{ salt['pillar.get']('collectd:FQDNLookup', 'false') }}
-        types: {{ salt['pillar.get']('collectd:TypesDB', ['/usr/share/collectd/types.db']) }}
-        default: {{ salt['pillar.get']('collectd:plugins:default', ['battery', 'cpu', 'entropy', 'load', 'memory', 'swap', 'users']) }}
-        plugindirconfig: {{ collectd.plugindirconfig }}
-        plugins: {{ salt['pillar.get']('collectd:plugins:enable', false) }}

--- a/collectd/interface.sls
+++ b/collectd/interface.sls
@@ -1,9 +1,9 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
 
-{{ collectd.plugindirconfig }}/interface.conf:
+{{ collectd_settings.plugindirconfig }}/interface.conf:
   file.managed:
     - source: salt://collectd/files/interface.conf
     - user: root
@@ -12,6 +12,3 @@ include:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        interfaces: {{ salt['pillar.get']('collectd:plugins:interface:interface', ['eth0']) }}
-        IgnoreSelected: {{ salt['pillar.get']('collectd:plugins:interface:IgnoreSelected', 'false') }}

--- a/collectd/java.sls
+++ b/collectd/java.sls
@@ -1,22 +1,22 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
 
 collectd-java:
     file.rename:
-        - name: {{ collectd.javalib }}
-        - source: {{ collectd.javalib }}.new
+        - name: {{ collectd_settings.javalib }}
+        - source: {{ collectd_settings.javalib }}.new
         - force: False
         - makedirs: False
 
-{{ collectd.javalib }}:
+{{ collectd_settings.javalib }}:
     file.symlink:
-        - target: {{ salt['pillar.get']('collectd:plugins:java:lib') }}
+        - target: {{ collectd_settings.plugins.java.lib }}
         - makedirs: False
 
 
-{{ collectd.plugindirconfig }}/java.conf:
+{{ collectd_settings.plugindirconfig }}/java.conf:
   file.managed:
     - source: salt://collectd/files/java.conf
     - user: root
@@ -25,9 +25,3 @@ collectd-java:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        host: {{ salt['pillar.get']('collectd:plugins:java:host', 'localhost') }}
-        port: {{ salt['pillar.get']('collectd:plugins:java:port', '17264') }}
-        user: {{ salt['pillar.get']('collectd:plugins:java:user', '') }}
-        pass: {{ salt['pillar.get']('collectd:plugins:java:pass', '') }}
-

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -1,15 +1,98 @@
-{% set collectd = salt['grains.filter_by']({
+{% set os_map = salt['grains.filter_by']({
     'Debian': {
-        'pkg': 'collectd-core',
-        'service': 'collectd',
         'config': '/etc/collectd/collectd.conf',
-        'plugindirconfig': '/etc/collectd/plugins',
         'javalib': '/usr/lib/collectd/java.so',
+        'pkg': 'collectd-core',
+        'plugindirconfig': '/etc/collectd/plugins',
+        'service': 'collectd',
+        'TypesDB': ['/usr/share/collectd/types.db'],
     },
     'RedHat': {
-        'pkg': 'collectd',
-        'service': 'collectd',
         'config': '/etc/collectd.conf',
+        'pkg': 'collectd',
         'plugindirconfig': '/etc/collectd.d',
+        'service': 'collectd',
+        'TypesDB': ['/usr/share/collectd/types.db'],
     },
 }, merge=salt['pillar.get']('collectd:lookup')) %}
+
+{# Settings dictionary with default values #}
+{% set default_settings = {
+    'collectd': {
+        'default_plugins': [
+            'battery',
+            'cpu',
+            'entropy',
+            'load',
+            'memory',
+            'swap',
+            'users'
+        ],
+        'FQDNLookup': 'false',
+        'plugins': {
+            'apache': {
+                'host': salt['grains.get']('host')
+            },
+            'df': {
+                'IgnoreSelected': 'false',
+                'ReportByDevice': 'false',
+                'ReportReserved': 'false',
+                'ReportInodes': 'false'
+            },
+            'disk': {
+                'matches': []
+            },
+            'enable': false,
+            'ethstat': {
+                'interface': 'eth0'
+            },
+            'interface': {
+                'interface': 'eth0',
+                'IgnoreSelected': 'false'
+            },
+            'java': {
+                'host': 'localhost',
+                'port': '17264',
+            },
+            'mysql': {
+                'databases': []
+            },
+            'network': {},
+            'nginx': {
+                'url': 'http://localhost/check_status',
+            },
+            'ntpd': {
+                'host': 'localhost',
+                'port': '123',
+                'ReverseLookups': 'false'
+            },
+            'ping': {
+                'hosts': ['google.com', 'yahoo.com'],
+                'hosts_from_grains': {},
+            },
+            'postgresql': {
+                'databases': []
+            },
+            'processes': {
+                'Processes': [],
+                'ProcessMatches': []
+            },
+            'statsd': {
+                'host': '"::"',
+                'port': 8125
+            },
+            'syslog': {
+                'loglevel': 'info'
+            },
+            'write_graphite': {
+                'node': salt['grains.get']('fqdn')
+            }
+        }
+    }
+} %}
+
+{# Merge os_map into settings dictionary #}
+{% do default_settings.collectd.update(os_map) %}
+
+{# Update settings defaults from pillar data #}
+{% set collectd_settings = salt['pillar.get']('collectd', default=default_settings.collectd, merge=True) %}

--- a/collectd/mysql.sls
+++ b/collectd/mysql.sls
@@ -1,9 +1,9 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
 
-{{ collectd.plugindirconfig }}/mysql.conf:
+{{ collectd_settings.plugindirconfig }}/mysql.conf:
   file.managed:
     - source: salt://collectd/files/mysql.conf
     - user: root
@@ -12,10 +12,3 @@ include:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        host: {{ salt['pillar.get']('collectd:plugins:mysql:host') }}
-        port: {{ salt['pillar.get']('collectd:plugins:mysql:port') }}
-        user: {{ salt['pillar.get']('collectd:plugins:mysql:user') }}
-        pass: {{ salt['pillar.get']('collectd:plugins:mysql:pass') }}
-        name: {{ salt['pillar.get']('collectd:plugins:mysql:name') }}
-        MasterStats: {{ salt['pillar.get']('collectd:plugins:mysql:MasterStats') }}

--- a/collectd/network.sls
+++ b/collectd/network.sls
@@ -1,9 +1,9 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
 
-{{ collectd.plugindirconfig }}/network.conf:
+{{ collectd_settings.plugindirconfig }}/network.conf:
   file.managed:
     - source: salt://collectd/files/network.conf
     - user: root
@@ -12,6 +12,3 @@ include:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        host: {{ salt['pillar.get']('collectd:plugins:network:host') }}
-        port: {{ salt['pillar.get']('collectd:plugins:network:port') }}

--- a/collectd/nginx.sls
+++ b/collectd/nginx.sls
@@ -1,9 +1,9 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
 
-{{ collectd.plugindirconfig }}/nginx.conf:
+{{ collectd_settings.plugindirconfig }}/nginx.conf:
   file.managed:
     - source: salt://collectd/files/nginx.conf
     - user: root
@@ -12,10 +12,3 @@ include:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        url: {{ salt['pillar.get']('collectd:plugins:nginx:url', 'http://localhost/check_status') }}
-        user: {{ salt['pillar.get']('collectd:plugins:nginx:user') }}
-        password: {{ salt['pillar.get']('collectd:plugins:nginx:password') }}
-        verifypeer: {{ salt['pillar.get']('collectd:plugins:nginx:verifypeer') }}
-        verifyhost: {{ salt['pillar.get']('collectd:plugins:nginx:verifyhost') }}
-        cacert: {{ salt['pillar.get']('collectd:plugins:nginx:cacert') }}

--- a/collectd/ntpd.sls
+++ b/collectd/ntpd.sls
@@ -1,9 +1,9 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
 
-{{ collectd.plugindirconfig }}/ntpd.conf:
+{{ collectd_settings.plugindirconfig }}/ntpd.conf:
   file.managed:
     - source: salt://collectd/files/ntpd.conf
     - user: root
@@ -12,10 +12,3 @@ include:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        host: {{ salt['pillar.get']('collectd:plugins:ntpd:host', 'localhost') }}
-        port: {{ salt['pillar.get']('collectd:plugins:ntpd:port', '123') }}
-        user: {{ salt['pillar.get']('collectd:plugins:ntpd:ReverseLookups', 'false') }}
-    - context:
-        ReverseLookups: {{ salt['pillar.get']('collectd:plugins:ntpd:ReverseLookups', 'false') }}
-

--- a/collectd/ping.sls
+++ b/collectd/ping.sls
@@ -1,4 +1,4 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
@@ -6,7 +6,7 @@ include:
 liboping0:
   pkg.installed
 
-{{ collectd.plugindirconfig }}/ping.conf:
+{{ collectd_settings.plugindirconfig }}/ping.conf:
   file.managed:
     - source: salt://collectd/files/ping.conf
     - user: root
@@ -17,12 +17,3 @@ liboping0:
       - pkg: liboping0
     - watch_in:
       - service: collectd-service
-    - defaults:
-        hosts: {{ salt['pillar.get']('collectd:plugins:ping:hosts', ['google.com', 'yahoo.com']) }}
-        hfg: {{ salt['pillar.get']('collectd:plugins:ping:hosts_from_grains') }}
-        interval: {{ salt['pillar.get']('collectd:plugins:ping:interval') }}
-        timeout: {{ salt['pillar.get']('collectd:plugins:ping:timeout') }}
-        ttl: {{ salt['pillar.get']('collectd:plugins:ping:ttl') }}
-        sourceaddress: {{ salt['pillar.get']('collectd:plugins:ping:sourceaddress') }}
-        device: {{ salt['pillar.get']('collectd:plugins:ping:device') }}
-        maxmissed: {{ salt['pillar.get']('collectd:plugins:ping:maxmissed') }}

--- a/collectd/postgresql.sls
+++ b/collectd/postgresql.sls
@@ -1,9 +1,10 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+{%- set postgresql_settings = collectd_settings.get('plugins:postgresql') %}
 
 include:
   - collectd
 
-{{ collectd.plugindirconfig }}/postgresql.conf:
+{{ collectd_settings.plugindirconfig }}/postgresql.conf:
   file.managed:
     - source: salt://collectd/files/postgresql.conf
     - user: root
@@ -12,11 +13,3 @@ include:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        databases:
-            - host: {{ salt['pillar.get']('collectd:plugins:postgresql:host') }}
-              port: {{ salt['pillar.get']('collectd:plugins:postgresql:port') }}
-              user: {{ salt['pillar.get']('collectd:plugins:postgresql:user') }}
-              pass: {{ salt['pillar.get']('collectd:plugins:postgresql:pass') }}
-              name: {{ salt['pillar.get']('collectd:plugins:postgresql:name') }}
-        # MasterStats: {{ salt['pillar.get']('collectd:plugins:postgresql:MasterStats') }}

--- a/collectd/processes.sls
+++ b/collectd/processes.sls
@@ -1,9 +1,9 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
 
-{{ collectd.plugindirconfig }}/processes.conf:
+{{ collectd_settings.plugindirconfig }}/processes.conf:
   file.managed:
     - source: salt://collectd/files/processes.conf
     - user: root
@@ -12,6 +12,3 @@ include:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-      Processes: {{ salt['pillar.get']('collectd:plugins:processes:processes', []) }}
-      ProcessMatches: {{ salt['pillar.get']('collectd:plugins:processes:processmatches', []) }}

--- a/collectd/service.sls
+++ b/collectd/service.sls
@@ -1,8 +1,8 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 collectd-service:
   service.running:
-    - name: {{ collectd.service }}
+    - name: {{ collectd_settings.service }}
     - enable: True
     - require:
-      - pkg: {{ collectd.pkg }}
+      - pkg: {{ collectd_settings.pkg }}

--- a/collectd/statsd.sls
+++ b/collectd/statsd.sls
@@ -1,9 +1,9 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
 
-{{ collectd.plugindirconfig }}/statsd.conf:
+{{ collectd_settings.plugindirconfig }}/statsd.conf:
   file.managed:
     - source: salt://collectd/files/statsd.conf
     - user: root
@@ -12,6 +12,3 @@ include:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        Host: {{ salt['pillar.get']('collectd:plugins:statsd:host', '"::"') }}
-        Port: {{ salt['pillar.get']('collectd:plugins:statsd:port', 8125) }}

--- a/collectd/syslog.sls
+++ b/collectd/syslog.sls
@@ -1,9 +1,9 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
 
-{{ collectd.plugindirconfig }}/syslog.conf:
+{{ collectd_settings.plugindirconfig }}/syslog.conf:
   file.managed:
     - source: salt://collectd/files/syslog.conf
     - user: root
@@ -12,5 +12,3 @@ include:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        LogLevel: {{ salt['pillar.get']('collectd:plugins:syslog:LogLevel', 'info') }}

--- a/collectd/write_graphite.sls
+++ b/collectd/write_graphite.sls
@@ -1,9 +1,9 @@
-{% from "collectd/map.jinja" import collectd with context %}
+{% from "collectd/map.jinja" import collectd_settings with context %}
 
 include:
   - collectd
 
-{{ collectd.plugindirconfig }}/write_graphite.conf:
+{{ collectd_settings.plugindirconfig }}/write_graphite.conf:
   file.managed:
     - source: salt://collectd/files/write_graphite.conf
     - user: root
@@ -12,15 +12,3 @@ include:
     - template: jinja
     - watch_in:
       - service: collectd-service
-    - defaults:
-        node: {{ salt['grains.get']('fqdn') }}
-        host: {{ salt['pillar.get']('collectd:plugins:write_graphite:host') }}
-        port: {{ salt['pillar.get']('collectd:plugins:write_graphite:port') }}
-        prefix: {{ salt['pillar.get']('collectd:plugins:write_graphite:prefix') }}
-        postfix: {{ salt['pillar.get']('collectd:plugins:write_graphite:postfix') }}
-        protocol: {{ salt['pillar.get']('collectd:plugins:write_graphite:protocol') }}
-        logsenderrors: {{ salt['pillar.get']('collectd:plugins:write_graphite:logsenderrors') }}
-        escapecharacter: {{ salt['pillar.get']('collectd:plugins:write_graphite:escapecharacter') }}
-        separateinstances: {{ salt['pillar.get']('collectd:plugins:write_graphite:separateinstances') }}
-        storerates: {{ salt['pillar.get']('collectd:plugins:write_graphite:storerates') }}
-        alwaysappendds: {{ salt['pillar.get']('collectd:plugins:write_graphite:alwaysappendds') }}

--- a/pillar.example
+++ b/pillar.example
@@ -5,23 +5,30 @@ collectd:
     default: [battery, cpu, entropy, load, memory, swap, users]
     enable: false
     syslog:
-      LogLevel: info
+      loglevel: info
     network:
       host: 'logstash'
       port: 25826
     mysql:
-      host: 'localhost'
-      port: '3306'
-      user: 'myuser'
-      pass: 'mypass'
-      name: 'mydb'
-      MasterStats: 'false'
+      databases:
+        - host: 'foo'
+          port: '3306'
+          user: 'myuser'
+          pass: 'mypass'
+          name: 'mydb'
+          masterstats: true
+        - host: 'foo'
+          name: 'mydb'
+          socket: '/var/run/mysql/mysqld.sock'
+          slavestats: true
+          slavenotifications: true
     postgresql:
-      host: 'localhost'
-      port: '5432'
-      user: 'myuser'
-      pass: 'mypass'
-      name: 'mydb'
+      databases:
+        - host: 'localhost'
+          port: '5432'
+          user: 'myuser'
+          pass: 'mypass'
+          name: 'mydb'
     df:
       Device:
       MountPoint:


### PR DESCRIPTION
    As recently discussed on salt-formulas it is preferred to keep settings (both
    distribution specific ones and defaults for pillar data) in map.jinja and rely
    on deep merging. This commit switches the formula to that style and thereby
    provides a single way to access *all* settings via the collect_settings
    dictionary.
    
    Pillar backwards compatibility was mostly kept, but it was necessary to adjust
    both the mysql and postgresql pillars to contain lists of dictionaries, rather
    than simply defining a single db over which the previous code then "iterated".
    
    Unfortunately it was also necessary to remove some symlink settings from the
    java plugin that is both unnecessary on, at least, Debian family minions and
    suffered from ill-defined defaults.