### PR TITLE
Ensure default plugins are set in collectd:plugins:default pillar

### DIFF
--- a/collectd/files/collectd.conf
+++ b/collectd/files/collectd.conf
@@ -19,7 +19,7 @@ TypesDB "{{ type }}"
 #Timeout 2
 #ReadThreads 5
 
-{% for plugin in collectd_settings.default_plugins %}
+{% for plugin in collectd_settings.plugins.default %}
 LoadPlugin {{ plugin }}
 {%- endfor %}
 

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -19,17 +19,17 @@
 {# Settings dictionary with default values #}
 {% set default_settings = {
     'collectd': {
-        'default_plugins': [
-            'battery',
-            'cpu',
-            'entropy',
-            'load',
-            'memory',
-            'swap',
-            'users'
-        ],
         'FQDNLookup': 'false',
         'plugins': {
+            'default': [
+                'battery',
+                'cpu',
+                'entropy',
+                'load',
+                'memory',
+                'swap',
+                'users'
+            ],
             'apache': {
                 'host': salt['grains.get']('host')
             },


### PR DESCRIPTION
I moved this to `collectd:default_plugins` earlier for a reason that is unclear to me now.