### PR TITLE
Fix ping plugin

### DIFF
--- a/collectd/files/ping.conf
+++ b/collectd/files/ping.conf
@@ -1,6 +1,7 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
-{%- set hfg = ping_settings.hosts_from_grains %}
+{%- set hosts = collectd_settings.plugins.ping.hosts %}
+{%- set hfg = collectd_settings.plugins.ping.hosts_from_grains %}
 
 {% if hfg and salt['mine.get'](hfg.target, hfg.fun, hfg.expr_form) -%}
 {% set hosts = hosts + salt['mine.get'](hfg.target, hfg.fun, hfg.expr_form).values() -%}
@@ -20,22 +21,22 @@ LoadPlugin ping
   Host "{{ host }}"
 {%- endfor %}
 
-{%- if collectd_settings.plugins.df.Device is defined and collectd_settings.plugins.df.Device %}
+{%- if collectd_settings.plugins.ping.Device is defined and collectd_settings.plugins.ping.Device %}
   Interval "{{ collectd_settings.plugins.ping.interval }}"
 {%- endif %}
-{%- if collectd_settings.plugins.df.Device is defined and collectd_settings.plugins.df.Device %}
+{%- if collectd_settings.plugins.ping.Device is defined and collectd_settings.plugins.ping.Device %}
   Timeout "{{ collectd_settings.plugins.ping.timeout }}"
 {%- endif %}
-{%- if collectd_settings.plugins.df.Device is defined and collectd_settings.plugins.df.Device %}
+{%- if collectd_settings.plugins.ping.Device is defined and collectd_settings.plugins.ping.Device %}
   TTL "{{ collectd_settings.plugins.ping.ttl }}"
 {%- endif %}
-{%- if collectd_settings.plugins.df.Device is defined and collectd_settings.plugins.df.Device %}
+{%- if collectd_settings.plugins.ping.Device is defined and collectd_settings.plugins.ping.Device %}
   SourceAddress "{{ collectd_settings.plugins.ping.sourceaddress }}"
 {%- endif %}
-{%- if collectd_settings.plugins.df.Device is defined and collectd_settings.plugins.df.Device %}
+{%- if collectd_settings.plugins.ping.Device is defined and collectd_settings.plugins.ping.Device %}
   Device "{{ collectd_settings.plugins.ping.device }}"
 {%- endif %}
-{%- if collectd_settings.plugins.df.Device is defined and collectd_settings.plugins.df.Device %}
+{%- if collectd_settings.plugins.ping.Device is defined and collectd_settings.plugins.ping.Device %}
   MaxMissed "{{ collectd_settings.plugins.ping.maxmissed }}"
 {%- endif %}
 </Plugin>


### PR DESCRIPTION
PR #25 broke the ping plugin. Just noticed. Here's the fix.

Lookup hosts_from_grains from the right place.

Use ping plugin settings (instead of df settings...)