### PR TITLE
Enable setting disk plugin IgnoreSelected option via pillar

### DIFF
--- a/collectd/files/disk.conf
+++ b/collectd/files/disk.conf
@@ -13,4 +13,5 @@ LoadPlugin disk
 {%- for match in collectd_settings.plugins.disk.matches %}
         Disk "{{ match}}"
 {%- endfor %}
+        IgnoreSelected "{{ collectd_settings.plugins.disk.IgnoreSelected }}"
 </Plugin>

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -53,7 +53,8 @@
                 'ReportInodes': 'false'
             },
             'disk': {
-                'matches': []
+                'matches': [],
+                'IgnoreSelected': 'false'
             },
             'enable': false,
             'ethstat': {


### PR DESCRIPTION
Enable setting disk plugin IgnoreSelected option via pillar using a default of false per collectd.conf(5)