### PR TITLE
Write_graphite plugin has missing properties

### DIFF
--- a/collectd/files/write_graphite.conf
+++ b/collectd/files/write_graphite.conf
@@ -15,11 +15,23 @@ LoadPlugin write_graphite
    Port "{{ collectd_settings.plugins.write_graphite.port }}"
    Prefix "{{ collectd_settings.plugins.write_graphite.prefix }}."
    Postfix "{{ collectd_settings.plugins.write_graphite.postfix }}"
+{%- if collectd_settings.plugins.write_graphite.protocol is defined and collectd_settings.plugins.write_graphite.protocol %}
    Protocol "{{ collectd_settings.plugins.write_graphite.protocol }}"
+{%- endif %}
+{%- if collectd_settings.plugins.write_graphite.escapecharacter is defined and collectd_settings.plugins.write_graphite.escapecharacter %}
    EscapeCharacter "{{ collectd_settings.plugins.write_graphite.escapecharacter }}"
+{%- endif %}
+{%- if collectd_settings.plugins.write_graphite.logsenderrors is defined and collectd_settings.plugins.write_graphite.logsenderrors %}
    LogSendErrors {{ collectd_settings.plugins.write_graphite.logsenderrors|lower }}
+{%- endif %}
+{%- if collectd_settings.plugins.write_graphite.separateinstances is defined and collectd_settings.plugins.write_graphite.separateinstances %}
    SeparateInstances {{ collectd_settings.plugins.write_graphite.separateinstances|lower }}
+{%- endif %}
+{%- if collectd_settings.plugins.write_graphite.storerates is defined and collectd_settings.plugins.write_graphite.storerates %}
    StoreRates {{ collectd_settings.plugins.write_graphite.storerates|lower }}
+{%- endif %}
+{%- if collectd_settings.plugins.write_graphite.alwaysappendds is defined and collectd_settings.plugins.write_graphite.alwaysappendds %}
    AlwaysAppendDS {{ collectd_settings.plugins.write_graphite.alwaysappendds|lower }}
+{%- endif %}
  </Carbon>
 </Plugin>


### PR DESCRIPTION
In the ```write_graphite``` plugin there are two options, which are not present in my version of ```collectd```: ```Protocol``` and ```LogSendErrors```. The errors given by collectd are:
> write_graphite plugin: Invalid configuration option: LogSendErrors.
write_graphite plugin: Invalid configuration option: Protocol.

The version is 5.1.0. This is pretty old I know, but it goes with Debian squezee.
I suppose, these options should be made optional. Mind if I send a pull request?