### PR TITLE
More fixes

### DIFF
--- a/collectd/files/collectd.conf
+++ b/collectd/files/collectd.conf
@@ -7,7 +7,7 @@
 # Modify the config that generates this file instead
 #
 
-Hostname "{{ salt['grains.get']('fqdn') }}"
+Hostname "{{ collectd_settings.Hostname }}"
 FQDNLookup {{ collectd_settings.FQDNLookup }}
 #BaseDir "/var/lib/collectd"
 #PluginDir "/usr/lib/collectd"
@@ -15,9 +15,9 @@ FQDNLookup {{ collectd_settings.FQDNLookup }}
 {% for type in collectd_settings.TypesDB %}
 TypesDB "{{ type }}"
 {%- endfor %}
-#Interval 10
-#Timeout 2
-#ReadThreads 5
+Interval {{ collectd_settings.Interval }}
+Timeout {{ collectd_settings.Timeout }}
+ReadThreads {{ collectd_settings.ReadThreads }}
 
 {% for plugin in collectd_settings.plugins.default %}
 LoadPlugin {{ plugin }}

--- a/collectd/files/df.conf
+++ b/collectd/files/df.conf
@@ -10,9 +10,9 @@
 LoadPlugin df
 
 <Plugin df>
-{%- if collectd_settings.plugins.df.Device is defined and collectd_settings.plugins.df.Device %}
-      Device "{{ collectd_settings.plugins.df.Device }}"
-{%- endif %}
+{%- for device in collectd_settings.plugins.df.Devices %}
+      Device "{{ device }}"
+{%- endfor %}
 {%- if collectd_settings.plugins.df.MountPoint is defined and collectd_settings.plugins.df.MountPoint %}
       MountPoint "{{ collectd_settings.plugins.df.MountPoint }}"
 {%- endif %}

--- a/collectd/files/mysql.conf
+++ b/collectd/files/mysql.conf
@@ -12,7 +12,7 @@ LoadPlugin mysql
 <Plugin mysql>
 
 {% for db in collectd_settings.plugins.mysql.databases %}
-      <Database db.name>
+      <Database {{ db.name }}>
               Host "{{ db.host }}"
 {%- if db.port is defined and db.port %}
               Port "{{ db.port }}"
@@ -23,11 +23,17 @@ LoadPlugin mysql
 {%- if db.pass is defined and db.pass %}
               Password "{{ db.pass }}"
 {%- endif %}
-{%- if db.name is defined and db.name %}
-              Database "{{ db.name }}"
+{%- if db.dbname is defined and db.dbname %}
+              Database "{{ db.dbname }}"
 {%- endif %}
 {%- if db.masterstats is defined and db.masterstats %}
-              MasterStats true
+              MasterStats {{ db.masterstats }}
+{%- endif %}
+{%- if db.slavestats is defined and db.slavestats %}
+              SlaveStats {{ db.slavestats }}
+{%- endif %}
+{%- if db.slavenotifications is defined and db.slavenotifications %}
+              SlaveNotifications {{ db.slavenotifications }}
 {%- endif %}
       </Database>
 {%- endfor %}

--- a/collectd/files/python.conf
+++ b/collectd/files/python.conf
@@ -8,7 +8,7 @@
 #
 
 <LoadPlugin python>
-    Globals {{ collectd_settings.plugins.python.Globals }}
+    Globals {{ collectd_settings.plugins.python.Globals | lower }}
 </LoadPlugin>
 
 <Plugin python>

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -73,12 +73,16 @@
                 'interface': 'eth0'
             },
             'interface': {
-                'interface': 'eth0',
+                'interfaces': ['eth0'],
                 'IgnoreSelected': 'false'
             },
             'java': {
                 'host': 'localhost',
                 'port': '17264',
+            },
+            'md': {
+                'Devices': [],
+                'IgnoreSelected': 'true'
             },
             'mysql': {
                 'databases': []
@@ -111,7 +115,10 @@
                 'loglevel': 'info'
             },
             'write_graphite': {
-                'node': salt['grains.get']('fqdn')
+                'host': salt['grains.get']('fqdn'),
+                'port': 2003,
+                'prefix': 'collectd',
+                'postfix': ''
             },
             'python': {
                 'Globals': 'true'

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -32,6 +32,10 @@
 {# Settings dictionary with default values #}
 {% set default_settings = {
     'collectd': {
+        'Hostname': salt['grains.get']('fqdn'),
+        'Interval': 10,
+        'Timeout': 2,
+        'ReadThreads': 5,
         'FQDNLookup': 'false',
         'plugins': {
             'default': [

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -58,6 +58,7 @@
                 ]
             },
             'df': {
+                'Devices': [],
                 'IgnoreSelected': 'false',
                 'ReportByDevice': 'false',
                 'ReportReserved': 'false',

--- a/pillar.example
+++ b/pillar.example
@@ -37,7 +37,9 @@ collectd:
           pass: 'mypass'
           name: 'mydb'
     df:
-      Device:
+      Devices:
+        - 'md1'
+        - 'md2'
       MountPoint:
       FSType: 'ext4'
       IgnoreSelected: false


### PR DESCRIPTION
What I have done here:
* Added more global configuration parameters.
* I believe hostname should be configurable, although with my patch I stay with backwards-compatible change.
* For df plugin: it should support many Devices.
* Mysql plugin: splitted db.name into two parameters: db.name and db.dbname.
Imagine you have two mysql instances on one server. One called ``first`` another: ``second``. Two add them into collectd you should have this kind of config:
```
<Plugin mysql>
    <Database first>
        Host 127.0.0.1
        Port 3306
        Database mysql
    </Database>
    <Database second>
        Host 127.0.0.1
        Port 3306
        Database mysql
    </Database>
</Plugin>
```
With old state, you couldn't do it.
* Added more default parameters. Without them it will fail now.