### PR TITLE
Make formula more flexible with packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,11 @@ Enables and configures the network plugin.
 
 Enables and configures the ntpd plugin.
 
+``collectd.packages``
+------------
+
+This state is used to install OS packages collectd plugins depend on.
+
 ``collectd.postgresql``
 ------------
 

--- a/collectd/init.sls
+++ b/collectd/init.sls
@@ -6,6 +6,9 @@ include:
 collectd:
   pkg.installed:
     - name: {{ collectd_settings.pkg }}
+    {%- if collectd_settings.pkg_version is defined and collectd_settings.pkg_version %}
+    - version: '{{ collectd_settings.pkg_version }}'
+    {%- endif %}
 
 {{ collectd_settings.plugindirconfig }}:
   file.directory:

--- a/collectd/packages.sls
+++ b/collectd/packages.sls
@@ -10,4 +10,6 @@ collectd_additional_packages:
   {%- for pkg in collectd_settings.additional_packages %}
       - {{ pkg.name }}{% if pkg.version is defined and pkg.version %}: '{{ pkg.version }}' {% endif %}
   {%- endfor %}
+    - watch_in:
+      - service: collectd-service
 {%- endif %}

--- a/collectd/packages.sls
+++ b/collectd/packages.sls
@@ -1,0 +1,13 @@
+{% from "collectd/map.jinja" import collectd_settings with context %}
+
+include:
+  - collectd
+
+{%- if collectd_settings.additional_packages is defined and collectd_settings.additional_packages %}
+collectd_additional_packages:
+  pkg.installed:
+    - pkgs:
+  {%- for pkg in collectd_settings.additional_packages %}
+      - {{ pkg.name }}{% if pkg.version is defined and pkg.version %}: '{{ pkg.version }}' {% endif %}
+  {%- endfor %}
+{%- endif %}


### PR DESCRIPTION
Firstly I believe ``collectd`` package version should be configurable. For example, I have legacy Debian squezze installations, which use version 4.6 by default, although there is 5.1 available in backports.

Secondly ``collectd-core`` doesn't install many packages one may need, but ``collectd`` installs too many of them. Nevertheless you may need even more packages.
So the ``collectd.packages`` is intended to manage all dependencies.