### PR TITLE
'FSType' and 'Mountpoint' should be multivalue in the df config

### DIFF
--- a/collectd/files/df.conf
+++ b/collectd/files/df.conf
@@ -18,10 +18,14 @@ LoadPlugin df
       Device "{{ device }}"
 {%- endfor %}
 {%- if collectd_settings.plugins.df.MountPoint is defined and collectd_settings.plugins.df.MountPoint %}
-      MountPoint "{{ collectd_settings.plugins.df.MountPoint }}"
+    {%- for mountpoint in collectd_settings.plugins.df.MountPoints %}
+      MountPoint "{{ mountpoint }}"
+    {%- endfor %}
 {%- endif %}
 {%- if collectd_settings.plugins.df.FSType is defined and collectd_settings.plugins.df.FSType %}
-      FSType "{{ collectd_settings.plugins.df.FSType }}"
+    {%- for fstype in collectd_settings.plugins.df.FSTypes %}
+      FSType "{{ fstype }}"
+    {%- endfor %}
 {%- endif %}
       IgnoreSelected "{{ collectd_settings.plugins.df.IgnoreSelected }}"
       ReportByDevice "{{ collectd_settings.plugins.df.ReportByDevice }}"

--- a/pillar.example
+++ b/pillar.example
@@ -60,8 +60,11 @@ collectd:
       Devices:
         - 'md1'
         - 'md2'
-      MountPoint:
-      FSType: 'ext4'
+      MountPoints:
+        - '/home'
+      FSTypes:
+        - 'ext4'
+        - 'tmpfs'
       IgnoreSelected: false
       ReportByDevice:
       ReportReserved:


### PR DESCRIPTION
This change allows multiple values to be specified for both the FSType and Mountpoint parameters. 

I pluralized the items in the pillar to more clearly indicate that it is a multivalue list, and to keep the field consistent with 'Devices' which already accepted multiple values. Unfortunately this may break existing pillar configurations.