### PR TITLE
fix pluralization in df config

### DIFF
--- a/collectd/files/df.conf
+++ b/collectd/files/df.conf
@@ -17,12 +17,12 @@ LoadPlugin df
 {%- for device in collectd_settings.plugins.df.Devices %}
       Device "{{ device }}"
 {%- endfor %}
-{%- if collectd_settings.plugins.df.MountPoint is defined and collectd_settings.plugins.df.MountPoint %}
+{%- if collectd_settings.plugins.df.MountPoints is defined and collectd_settings.plugins.df.MountPoints %}
     {%- for mountpoint in collectd_settings.plugins.df.MountPoints %}
       MountPoint "{{ mountpoint }}"
     {%- endfor %}
 {%- endif %}
-{%- if collectd_settings.plugins.df.FSType is defined and collectd_settings.plugins.df.FSType %}
+{%- if collectd_settings.plugins.df.FSTypes is defined and collectd_settings.plugins.df.FSTypes %}
     {%- for fstype in collectd_settings.plugins.df.FSTypes %}
       FSType "{{ fstype }}"
     {%- endfor %}


### PR DESCRIPTION
As an addendum to my last pull request, fix the pluralization of the parameters that were updated. Unfortunately, I updated the pluralization after I tested the change, and missed a few instances. Thats what I get for trying to sneak a seemingly trivial spelling change without re-testing. Apologies for that.