### PR TITLE
Support Python plugins without configuration variables

### DIFF
--- a/collectd/files/python.conf
+++ b/collectd/files/python.conf
@@ -18,10 +18,12 @@
 
 {%- for module in collectd_settings.plugins.python.modules %}
     Import "{{ module.name }}"
+    {%- if module.variables is defined %}
     <Module {{ module.name }}>
     {%- for key, value in module.variables.iteritems() %}
         {{ key }} {{ value }}
     {%- endfor %}
     </Module>
+    {%- endif %}
 {%- endfor %}
 </Plugin>


### PR DESCRIPTION
This allows to NOT set a ``variables`` value for a Python module if it
doesn't need configuration, which fixes two problems:

* if ``variables`` wasn't set, the template failed to render due an
  unknown variable in the for-loop inside the <Module> block
* if ``variables`` was set to an empty dict, collectd then refused to
  start because it somehow doesn't support <Module> block with no
  content.