### PR TITLE
Install dependencies when activating plugins

### DIFF
--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -9,6 +9,11 @@
         'moduledirconfig': '/usr/share/collectd/modules',
         'user': 'root',
         'group': 'root',
+        'plugins_deps': {
+            'python': ['libpython2.7'],
+            'mysql': ['libmysqlclient18', 'zlib1g'],
+            'ping': ['liboping0'],
+        }
     },
     'RedHat': {
         'config': '/etc/collectd.conf',
@@ -19,6 +24,11 @@
         'moduledirconfig': '/usr/share/collectd/modules',
         'user': 'root',
         'group': 'root',
+        'plugins_deps': {
+            'python': [],
+            'mysql': [],
+            'ping': [],
+        }
     },
     'FreeBSD': {
         'config': '/usr/local/etc/collectd.conf',
@@ -29,6 +39,11 @@
         'moduledirconfig': '/usr/local/share/collectd/modules',
         'user': 'root',
         'group': 'wheel',
+        'plugins_deps': {
+            'python': [],
+            'mysql': [],
+            'ping': [],
+        }
     },
 }, merge=salt['pillar.get']('collectd:lookup')) %}
 

--- a/collectd/mysql.sls
+++ b/collectd/mysql.sls
@@ -3,6 +3,16 @@
 include:
   - collectd
 
+
+{% if collectd_settings.plugins_deps.mysql %}
+collectd-mysql-dependencies:
+  pkg.installed:
+    - names: {{ collectd_settings.plugins_deps.mysql }}
+    - require_in:
+      - file: {{ collectd_settings.plugindirconfig }}/mysql.conf
+{% endif %}
+
+
 {{ collectd_settings.plugindirconfig }}/mysql.conf:
   file.managed:
     - source: salt://collectd/files/mysql.conf

--- a/collectd/ping.sls
+++ b/collectd/ping.sls
@@ -3,8 +3,15 @@
 include:
   - collectd
 
-liboping0:
-  pkg.installed
+
+{% if collectd_settings.plugins_deps.ping %}
+collectd-ping-dependencies:
+  pkg.installed:
+    - names: {{ collectd_settings.plugins_deps.ping }}
+    - require_in:
+      - file: {{ collectd_settings.plugindirconfig }}/ping.conf
+{% endif %}
+
 
 {{ collectd_settings.plugindirconfig }}/ping.conf:
   file.managed:
@@ -13,7 +20,5 @@ liboping0:
     - group: {{ collectd_settings.group }}
     - mode: 644
     - template: jinja
-    - require:
-      - pkg: liboping0
     - watch_in:
       - service: collectd-service

--- a/collectd/python.sls
+++ b/collectd/python.sls
@@ -3,6 +3,16 @@
 include:
   - collectd
 
+
+{% if collectd_settings.plugins_deps.python %}
+collectd-python-dependencies:
+  pkg.installed:
+    - names: {{ collectd_settings.plugins_deps.python }}
+    - require_in:
+      - file: {{ collectd_settings.plugindirconfig }}/python.conf
+{% endif %}
+
+
 {{ collectd_settings.plugindirconfig }}/python.conf:
   file.managed:
     - source: salt://collectd/files/python.conf


### PR DESCRIPTION
This library is not a direct dependency of the collectd package, but is
required to execute the Python plugin, at least on Debian distributions.

I'm not sure how it works on non-Debian distribution though. It should be as fine as the dependency on the liboping package in the ping state?
