### PR TITLE
Python plugin improvements

### DIFF
--- a/collectd/files/python.conf
+++ b/collectd/files/python.conf
@@ -20,7 +20,7 @@
     Import "{{ module.name }}"
     {%- if module.variables is defined %}
     <Module "{{ module.name }}">
-    {%- for key, value in module.variables.iteritems() %}
+    {%- for key, value in module.variables | dictsort %}
         {{ key }} {{ value }}
     {%- endfor %}
     </Module>

--- a/collectd/files/python.conf
+++ b/collectd/files/python.conf
@@ -19,7 +19,7 @@
 {%- for module in collectd_settings.plugins.python.modules %}
     Import "{{ module.name }}"
     {%- if module.variables is defined %}
-    <Module {{ module.name }}>
+    <Module "{{ module.name }}">
     {%- for key, value in module.variables.iteritems() %}
         {{ key }} {{ value }}
     {%- endfor %}


### PR DESCRIPTION
This provides a fix for when the module name is not entirely a "string" and improve the generation of the configuration file by sorting the attributes of the plugin.