### PR TITLE
Add support for the df ValuesPercentage setting

### DIFF
--- a/collectd/files/df.conf
+++ b/collectd/files/df.conf
@@ -31,4 +31,5 @@ LoadPlugin df
       ReportByDevice "{{ collectd_settings.plugins.df.ReportByDevice }}"
       ReportReserved "{{ collectd_settings.plugins.df.ReportReserved }}"
       ReportInodes "{{ collectd_settings.plugins.df.ReportInodes }}"
+      ValuesPercentage "{{ collectd_settings.plugins.df.ValuesPercentage }}"
 </Plugin>

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -65,7 +65,8 @@
                 'IgnoreSelected': 'false',
                 'ReportByDevice': 'false',
                 'ReportReserved': 'false',
-                'ReportInodes': 'false'
+                'ReportInodes': 'false',
+                'ValuesPercentage': 'false'
             },
             'disk': {
                 'matches': [],


### PR DESCRIPTION
The collectd [df plugin](https://collectd.org/wiki/index.php/Plugin:DF) supports reporting free/used space as percentages by setting `ValuesPercentage` to true. This PR lets us define that setting in the pillar data.