### PR TITLE
Avoid memory issue if one of the write plugins is slow/unavailable (e.g. graphite) by limiting the queue size

### DIFF
--- a/collectd/files/collectd.conf
+++ b/collectd/files/collectd.conf
@@ -20,6 +20,7 @@ Timeout {{ collectd_settings.Timeout }}
 ReadThreads {{ collectd_settings.ReadThreads }}
 WriteQueueLimitHigh {{ collectd_settings.WriteQueueLimitHigh  }} 
 WriteQueueLimitLow {{ collectd_settings.WriteQueueLimitLow  }}
+CollectInternalStats {{ collectd_settings.CollectInternalStats }}
 
 {% for plugin in collectd_settings.plugins.default %}
 LoadPlugin {{ plugin }}

--- a/collectd/files/collectd.conf
+++ b/collectd/files/collectd.conf
@@ -18,6 +18,8 @@ TypesDB "{{ type }}"
 Interval {{ collectd_settings.Interval }}
 Timeout {{ collectd_settings.Timeout }}
 ReadThreads {{ collectd_settings.ReadThreads }}
+WriteQueueLimitHigh {{ collectd_settings.WriteQueueLimitHigh  }} 
+WriteQueueLimitLow {{ collectd_settings.WriteQueueLimitLow  }}
 
 {% for plugin in collectd_settings.plugins.default %}
 LoadPlugin {{ plugin }}

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -41,6 +41,7 @@
         'ReadThreads': 5,
         'WriteQueueLimitHigh': 2000000,
         'WriteQueueLimitLow': 1800000,
+        'CollectInternalStats': 'false',
         'FQDNLookup': 'false',
         'plugins': {
             'default': [

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -39,6 +39,8 @@
         'Interval': 10,
         'Timeout': 2,
         'ReadThreads': 5,
+        'WriteQueueLimitHigh': 2000000,
+        'WriteQueueLimitLow': 1800000,
         'FQDNLookup': 'false',
         'plugins': {
             'default': [


### PR DESCRIPTION
From the doc : http://collectd.org/documentation/manpages/collectd.conf.5.shtml#global_options

Find these options after OOM on my server 