### PR TITLE
Modified the template for java plugin configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Collectd formula
 ================
 
+1.1.x (unreleased)
+
+- The creation of a symlink for `javalib` is optional and controlled by the parameter found in the pillar. If the `collected.plugins.java.lib` value is not present, the symlink is not created, thus avoiding a highstate failure. Resolves issue 26_.
+
+.. _26: https://github.com/saltstack-formulas/collectd-formula/issues/26
+
+
 1.1.0
 
 Feature release:

--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,22 @@ Enables and configures the interface plugin.
 
 Enables and configures the java plugin.
 
+Requires the installation of JDK.
+
+Pillar values used under `collectd.plugins.java`, an example:
+
+
+.. code-block:: yaml
+
+collectd:
+  plugins:
+    java:
+      host: localhost
+      port: 39999
+      user: 'someuser' (optional)
+      group: 'someuser' (optional)
+      lib: '/some/file' (optional)
+
 ``collectd.modules``
 --------------------
 

--- a/collectd/java.sls
+++ b/collectd/java.sls
@@ -10,11 +10,12 @@ collectd-java:
         - force: False
         - makedirs: False
 
+{% if collectd_settings.plugins.java.lib is defined and collectd_settings.plugins.java.lib %}
 {{ collectd_settings.javalib }}:
     file.symlink:
         - target: {{ collectd_settings.plugins.java.lib }}
         - makedirs: False
-
+{% endif %}
 
 {{ collectd_settings.plugindirconfig }}/java.conf:
   file.managed:


### PR DESCRIPTION
  - modified jinjia template in `collected/java.sls` so that the link is created only if the `collectd.plugins.java.lib` key exists
  - updated CHANGELOG and README with additional information about this change and the java plugin