### PR TITLE
this file has passwords in it (under this very formula); therefore, 644 is wrong

### DIFF
--- a/collectd/network.sls
+++ b/collectd/network.sls
@@ -8,7 +8,7 @@ include:
     - source: salt://collectd/files/network.conf
     - user: {{ collectd_settings.user }}
     - group: {{ collectd_settings.group }}
-    - mode: 644
+    - mode: '0600'
     - template: jinja
     - watch_in:
       - service: collectd-service


### PR DESCRIPTION
I would think this is fairly critical to merge. How many hosts have the collectd password sitting there in the open for anyone that can log into it? Single user operations may not care ... but sites with hundreds of devs surely would.