### PR TITLE
Add Exec Plugin support

### DIFF
--- a/collectd/exec.sls
+++ b/collectd/exec.sls
@@ -1,0 +1,14 @@
+{% from "collectd/map.jinja" import collectd_settings with context %}
+
+include:
+  - collectd
+
+{{ collectd_settings.plugindirconfig }}/exec.conf:
+  file.managed:
+    - source: salt://collectd/files/exec.conf
+    - user: {{ collectd_settings.user }}
+    - group: {{ collectd_settings.group }}
+    - mode: 644
+    - template: jinja
+    - watch_in:
+      - service: collectd-service

--- a/collectd/files/exec.conf
+++ b/collectd/files/exec.conf
@@ -1,0 +1,18 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
+LoadPlugin exec
+
+{%- if collectd_settings.plugins.exec is defined and collectd_settings.plugins.exec %}
+<Plugin "exec">
+  {%- for exec_line in collectd_settings.plugins.exec %}
+  {{ exec_line }}
+  {%- endfor %}
+</Plugin>
+{%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -30,6 +30,10 @@ collectd:
               value: user
             - name: password
               value: pass
+    exec:
+      - Exec "myuser:mygroup" "myprog"
+      - Exec "otheruser" "/path/to/another/binary" "arg0" "arg1"
+      - NotificationExec "user" "/usr/lib/collectd/exec/handle_notification"
     syslog:
       loglevel: info
     network:


### PR DESCRIPTION
* This does not manage the scripts being called or users specified to
  run the scripts. This only centralises the ability to configure it
  through one place with pillar.