### PR TITLE
Add default values for python module

### DIFF
--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -130,7 +130,9 @@
                 'postfix': ''
             },
             'python': {
-                'Globals': 'true'
+                'Globals': 'true',
+                'LogTraces': 'true',
+                'Interactive': 'false'
             },
             'elasticsearch': {
             	'host': 'localhost',


### PR DESCRIPTION
``collectd.python`` will fail unless you specify some default values in pillar. This PR fixes this.
I catched this when used ``collectd.redis_info`` which includes ``collectd.python`` [here](https://github.com/saltstack-formulas/collectd-formula/blob/df7be63091fabfd5f02ee095322d8ec1e0a116cc/collectd/redis_info.sls#L5). I consider this dependency isn't actually necessary. Maybe, we should remove it too?