### PR TITLE
Add state to render generic plugin configs.

### DIFF
--- a/collectd/extra-plugins.sls
+++ b/collectd/extra-plugins.sls
@@ -1,0 +1,19 @@
+{% from "collectd/map.jinja" import collectd_settings with context %}
+
+include:
+  - collectd
+
+{%- for plugin, plugin_settings in collectd_settings.plugins.extra.iteritems() %}
+{{ collectd_settings.plugindirconfig }}/{{ plugin }}.conf:
+  file.managed:
+    - source: salt://collectd/files/extra.conf
+    - user: {{ collectd_settings.user }}
+    - group: {{ collectd_settings.group }}
+    - mode: 644
+    - template: jinja
+    - defaults:
+        plugin: {{ plugin }}
+        plugin_settings: {{ plugin_settings }}
+    - watch_in:
+      - service: collectd-service
+{% endfor %}

--- a/collectd/files/extra.conf
+++ b/collectd/files/extra.conf
@@ -1,0 +1,26 @@
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
+{%- macro format_value(value) -%}
+  {%- if value is sameas true -%}
+true
+  {%- elif value is sameas false -%}
+false
+  {%- elif value is number -%}
+{{ value }}
+  {%- else -%}
+"{{ value }}"
+  {%- endif %}
+{%- endmacro -%}
+
+LoadPlugin {{ plugin }}
+
+<Plugin "{{ plugin }}">
+  {%- for name, value in (plugin_settings|default({})).iteritems() %}
+  {{ name }} {{ format_value(value )}}
+  {%- endfor %}
+</Plugin>

--- a/collectd/files/extra.conf
+++ b/collectd/files/extra.conf
@@ -15,7 +15,7 @@ false
   {%- else -%}
 "{{ value }}"
   {%- endif %}
-{%- endmacro -%}
+{%- endmacro %}
 
 LoadPlugin {{ plugin }}
 

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -53,6 +53,7 @@
                 'swap',
                 'users'
             ],
+            'extra': {},
             'apache': {
                 'instances' : [ {
                         'name': 'name',

--- a/pillar.example
+++ b/pillar.example
@@ -147,3 +147,6 @@ collectd:
           variables:
             var1: value1
             var2: value2
+    extra:
+      cpu:
+        ReportByCpu: false


### PR DESCRIPTION
This is a state to render plugins in a generic way, without having to be aware of their specific options. I made this to handle setting the CPU options (as in the pillar.example), but it should work for numerous other plugins as well.