### PR TITLE
Allow using local hostname for global Hostname

### DIFF
--- a/collectd/files/collectd.conf
+++ b/collectd/files/collectd.conf
@@ -7,8 +7,11 @@
 # Modify the config that generates this file instead
 #
 
+{%- if collectd_settings.Hostname is defined and collectd_settings.Hostname %}
 Hostname "{{ collectd_settings.Hostname }}"
-FQDNLookup {{ collectd_settings.FQDNLookup }}
+{%- else -%}
+FQDNLookup "{{ collectd_settings.FQDNLookup|lower }}"
+{%- endif %}
 #BaseDir "/var/lib/collectd"
 #PluginDir "/usr/lib/collectd"
 

--- a/collectd/files/collectd.conf
+++ b/collectd/files/collectd.conf
@@ -7,11 +7,11 @@
 # Modify the config that generates this file instead
 #
 
-{%- if collectd_settings.Hostname is defined and collectd_settings.Hostname %}
+{% if collectd_settings.Hostname is defined and collectd_settings.Hostname -%}
 Hostname "{{ collectd_settings.Hostname }}"
-{%- else -%}
+{% else -%}
 FQDNLookup "{{ collectd_settings.FQDNLookup|lower }}"
-{%- endif %}
+{% endif -%}
 #BaseDir "/var/lib/collectd"
 #PluginDir "/usr/lib/collectd"
 

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -35,14 +35,13 @@
 {# Settings dictionary with default values #}
 {% set default_settings = {
     'collectd': {
-        'Hostname': salt['grains.get']('fqdn'),
         'Interval': 10,
         'Timeout': 2,
         'ReadThreads': 5,
         'WriteQueueLimitHigh': 2000000,
         'WriteQueueLimitLow': 1800000,
         'CollectInternalStats': 'false',
-        'FQDNLookup': 'false',
+        'FQDNLookup': 'true',
         'plugins': {
             'default': [
                 'battery',

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,8 @@
 collectd:
-  FQDNLookup: true
+  # This line restores the old behaviour, comment it out to use the system's hostname
+  Hostname: {{ salt['grains.get']('fqdn') }}
+  # If Hostname is not defined, whether collectd will try to figure it out as a FQDN (default: true)
+  FQDNLookup: false
   TypesDB: ['/usr/share/collectd/types.db']
   plugins:
     default: [battery, cpu, entropy, load, memory, swap, users]


### PR DESCRIPTION
Note: this patch changes collectd's behaviour if grains['fqdn'] is not
the same as the output of hostname -f.  Restore the old behaviour by
setting this in the collectd piller:

  Hostname: {{ salt['grains.get']('fqdn') }}

With this patch Hostname is only set in collectd.conf if it is set in
the pillar data.  If it is not set collectd will determine it using
gethostname(2).  FQDNLookup is set in collectd.conf as follows:

- Hostname set: FQDNLookup not set (would be ignored by collectd)

- Hostname not set: FQDNLookup set from pillar data or default true