### PR TITLE
new option to purge plugindir from non salt-managed files

### DIFF
--- a/collectd/init.sls
+++ b/collectd/init.sls
@@ -17,6 +17,7 @@ collectd:
     - dir_mode: 755
     - file_mode: 644
     - makedirs: True
+    - clean: {{ collectd_settings.purge_plugindir }}
     - require_in:
       - service: collectd-service # set proper file mode before service runs
 

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -43,6 +43,7 @@
         'WriteQueueLimitLow': 1800000,
         'CollectInternalStats': 'false',
         'FQDNLookup': 'false',
+        'purge_plugindir': 'false',
         'plugins': {
             'default': [
                 'battery',

--- a/pillar.example
+++ b/pillar.example
@@ -3,6 +3,7 @@ collectd:
   TypesDB: ['/usr/share/collectd/types.db']
   types:
     - 'jmx_memory  value:GAUGE:0:U'
+  purge_plugindir: false        # if true, all non salt-managed files in plugindir will be removed
   plugins:
     default: [battery, cpu, entropy, load, memory, swap, users]
     curl_json:


### PR DESCRIPTION
Following issue #76 i made this tiny change to add an option to purge plugindir.
It's not in a specific state, because it's only two lines and it seems overkill to me.
Tell me what you think.
