### PR TITLE
Add configuration for tcpconns plugin

### DIFF
--- a/collectd/files/tcpconns.conf
+++ b/collectd/files/tcpconns.conf
@@ -1,0 +1,20 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+#
+# DO NOT EDIT
+#
+# This file is managed by salt via {{ source }}
+# Modify the config that generates this file instead
+#
+
+LoadPlugin tcpconns
+
+<Plugin "tcpconns">
+  ListeningPorts {{ collectd_settings.plugins.tcpconns.listening_ports | lower }}
+{%- for local_port in collectd_settings.plugins.tcpconns.local_ports %}
+  LocalPort "{{ local_port }}"
+{%- endfor %}
+{%- for remote_port in collectd_settings.plugins.tcpconns.remote_ports %}
+  RemotePort "{{ remote_port }}"
+{%- endfor %}
+</Plugin>
+

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -157,6 +157,11 @@
                 'datadir': '/var/lib/collectd/rrd',
                 'cacheflush': 120,
                 'writespersecond': 50
+            },
+            'tcpconns': {
+              'listening_ports': 'true',
+              'local_ports': [],
+              'remote_ports': []
             }
         }
     }

--- a/collectd/tcpconns.sls
+++ b/collectd/tcpconns.sls
@@ -1,0 +1,15 @@
+{% from "collectd/map.jinja" import collectd_settings with context %}
+
+include:
+  - collectd
+
+{{ collectd_settings.plugindirconfig }}/tcpconns.conf:
+  file.managed:
+    - source: salt://collectd/files/tcpconns.conf
+    - user: {{ collectd_settings.user }}
+    - group: {{ collectd_settings.group }}
+    - mode: 644
+    - template: jinja
+    - watch_in:
+      - service: collectd-service
+

--- a/pillar.example
+++ b/pillar.example
@@ -150,3 +150,7 @@ collectd:
     extra:
       cpu:
         ReportByCpu: false
+    tcpconns:
+      listening_ports: 'true'
+      local_ports: []
+      remote_ports: []


### PR DESCRIPTION

This adds the required configuration for the TCP connections plugin that ships with collectd.