### PR TITLE
Fix service dependencies for ntpd, elasticsearch and redis

### DIFF
--- a/collectd/elasticsearch.sls
+++ b/collectd/elasticsearch.sls
@@ -8,9 +8,9 @@ collectd-elasticsearch-module:
   pip.installed:
   - name: git+https://github.com/ministryofjustice/elasticsearch-collectd-plugin
   - require_in:
-    - service: collectd
+    - service: collectd-service
   - watch_in:
-    - service: collectd
+    - service: collectd-service
 
 
 {{ collectd_settings.plugindirconfig }}/elasticsearch.conf:

--- a/collectd/ntpd.sls
+++ b/collectd/ntpd.sls
@@ -8,9 +8,9 @@ collectd-ntp-module:
   pip.installed:
   - name: collectd-ntp == 0.0.4
   - require_in:
-    - service: collectd
+    - service: collectd-service
   - watch_in:
-    - service: collectd
+    - service: collectd-service
 
 {{ collectd_settings.plugindirconfig }}/ntpd.conf:
   file.managed:

--- a/collectd/redis_info.sls
+++ b/collectd/redis_info.sls
@@ -8,9 +8,9 @@ collectd-redis-module:
   pip.installed:
   - name: git+https://github.com/ministryofjustice/redis-collectd-plugin@make-it-a-pip
   - require_in:
-    - service: collectd
+    - service: collectd-service
   - watch_in:
-    - service: collectd
+    - service: collectd-service
 
 {{ collectd_settings.plugindirconfig }}/redis_info.conf:
   file.managed:


### PR DESCRIPTION

The various service dependencies were listed inconsistently in the ntpd, elasticsearch and redis plugins. This PR addresses this issue.