### PR TITLE
Change to use signalfx elasticsearch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Enables and configures the disk plugin.
 ``collectd.elasticsearch``
 --------------------------
 
-Enables and configures the `elasticsearch plugin <https://github.com/ministryofjustice/elasticsearch-collectd-plugin>`_
+Enables and configures the `elasticsearch plugin <https://github.com/signalfx/collectd-elasticsearch>`_
 
 ``collectd.ethstat``
 --------------------

--- a/collectd/elasticsearch.sls
+++ b/collectd/elasticsearch.sls
@@ -2,7 +2,6 @@
 
 include:
   - collectd
-  - collectd.python
 
 collectd-elasticsearch-module:
   git.latest:

--- a/collectd/elasticsearch.sls
+++ b/collectd/elasticsearch.sls
@@ -5,8 +5,10 @@ include:
   - collectd.python
 
 collectd-elasticsearch-module:
-  pip.installed:
-  - name: git+https://github.com/ministryofjustice/elasticsearch-collectd-plugin
+  git.latest:
+  - name: https://github.com/signalfx/collectd-elasticsearch
+  - rev: {{ collectd_settings.plugins.elasticsearch.gitrevision }}
+  - target: /usr/share/collectd/collectd-elasticsearch
   - require_in:
     - service: collectd-service
   - watch_in:

--- a/collectd/files/elasticsearch.conf
+++ b/collectd/files/elasticsearch.conf
@@ -86,13 +86,25 @@
     Host "{{ collectd_settings.plugins.elasticsearch.host }}"
     Port {{ collectd_settings.plugins.elasticsearch.port }}
     Cluster "{{ collectd_settings.plugins.elasticsearch.cluster }}"
-    Indexes {{ collectd_settings.plugins.elasticsearch.indexes }}
+    Indexes [
+{%- for index in collectd_settings.plugins.elasticsearch.indexes -%}
+    "{{ index }}"{% if not loop.last %},{% endif -%}
+{%- endfor -%}
+    ]
     EnableIndexStats {{ collectd_settings.plugins.elasticsearch.index_stats|lower }}
     EnableClusterHealth {{ collectd_settings.plugins.elasticsearch.cluster_health|lower }}
     Interval {{ collectd_settings.plugins.elasticsearch.interval }}
     IndexInterval {{ collectd_settings.plugins.elasticsearch.index_interval }}
     DetailedMetrics {{ collectd_settings.plugins.elasticsearch.detailed_metrics|lower }}
-    ThreadPools {{ collectd_settings.plugins.elasticsearch.thread_pools }}
-    AdditionalMetrics {{ collectd_settings.plugins.elasticsearch.additional_metrics }}
+    ThreadPools [
+{%- for thread_pool in collectd_settings.plugins.elasticsearch.thread_pools -%}
+    "{{ thread_pool }}"{% if not loop.last %},{% endif -%}
+{%- endfor -%}
+    ]
+    AdditionalMetrics [
+{%- for metric in collectd_settings.plugins.elasticsearch.additional_metrics -%}
+    "{{ metric }}"{% if not loop.last %},{% endif -%}
+{%- endfor -%}
+    ]
   </Module>
 </Plugin>

--- a/collectd/files/elasticsearch.conf
+++ b/collectd/files/elasticsearch.conf
@@ -1,19 +1,98 @@
 {%- from "collectd/map.jinja" import collectd_settings with context %}
 
+# Install:
+#   This is a Python-based plugin using third-party code by SignalFx. Clone the
+#   plugin's repository and install its Python dependencies:
+#     git clone \
+#         https://github.com/signalfx/collectd-elasticsearch.git \
+#         /usr/share/collectd/collectd-elasticsearch
+#     service collectd restart
+
+# Documentation:
+#   https://github.com/signalfx/collectd-elasticsearch.git
+
+# System modifications:
+#   None
+
+# Config file modifications:
+#   - The defaults should work for a recent, standard Elasticsearch installation.
+#   - Change Cluster to match the cluster name that is configured by Elasticsearch.
+#   - Enable/disable cluster health stats. These are enabled by default.
+#   - Enable/disable index stats. These are disabled by default. SignalFx recommends 
+#      enabling index stats collection only on master-eligible Elasticsearch nodes. 
+#   - Configuring per-index statistics:
+#      To retrieve statistics for a specific index, you can set the Index configuration
+#      option with the name of the index. For example Indexes ["index1"]. You can also
+#      set it to multiple indexes in a comma separated format : Indexes ["index1", "index2"].
+#      To retrieve statistics for all indexes, use the special "_all" index : Indexes ["_all"]
+#      To disable index statistic collection set EnableIndexStats to false.
+#
+#     You may specify which thread pools you would like to collect metrics for
+#     with a comma separated list of threadpool names. "search" and "index" are required to
+#     properly populate the default dashboards.
+#     The following threadpool names are acceptable:
+#       - Common to all supported versions: generic, get, snapshot, bulk, warmer, flush, refresh
+#       - 1.x only: merge, optimize
+#       - ES 2.0 +: suggest, percolate, management, listener, fetch_shard_store, fetch_shard_started
+#       - ES 2.1 +: force_merge
+#
+#     Ex.
+#        ThreadPools ["generic","index","get","snapshot","bulk","warmer","flush","search","refresh"]
+#
+#   - The plugin assumes Elasticsearch is accessible on localhost:9200.  If you need to specify
+#     a different host and port.  Use assign the appropriate host and port to "Host" and "Port"
+#     Ex.
+#         Host alternate_hostname
+#         Port 9320
+#
+#   - The DetailedMetrics setting enables the emission of all metrics collected by the plugin.
+#     Detailed metrics may be turned on by setting DetailedMetrics to the 
+#     appropriate boolean value 'true' or 'false'.  If the value is false a minimal set of default values
+#     will be collected.
+#     Ex.
+#         DetailedMetrics true
+#     If you wish to specify individual additional metrics please use the AdditionalDefaultMetrics (below)
+#
+#   - By default the Index stats are emitted every 300 seconds.  The 'IndexInterval'
+#     is configurable with an integer number of seconds.  It must be greater than or equal to
+#     and divisible by the configured 'Interval'.  If an incompatible 'IndexInterval' is configured,
+#     it will be rounded up to the configured 'Interval' or to the next highest compatible interval time
+#
+#   - Additional Default Metric values can be specified in a python list.  Note that the metric
+#     That are specified must match the metric names as defined in the elasticsearch_collectd.py file.
+#     Ex.
+#        AdditionalDefaultMetrics ["jvm.mem.non-heap-used", "jvm.mem.pools.young.max_in_bytes"]
+#     If no additional metrics are desired, assign a list with a blank string entry to AdditionalDefaultMetrics
+#     Ex.
+#        AdditionalDefaultMetrics [""]
+#
+#   - Basic Authentication support:
+#      If your Elasticsearch installation has basic authentication set up, then you may specify
+#      a username and password in this file by setting the properties "Username" and "Password"
+#      with the corresponding values.
+
+
 <LoadPlugin "python">
-    Globals true
+  Globals true
 </LoadPlugin>
 
 <Plugin "python">
-    ModulePath "{{ collectd_settings.moduledirconfig }}"
+  ModulePath "/usr/share/collectd/collectd-elasticsearch"
 
-    Import "elasticsearch"
+  Import "elasticsearch_collectd"
 
-    <Module "elasticsearch">
-        Host {{ collectd_settings.plugins.elasticsearch.host }}
-        Port {{ collectd_settings.plugins.elasticsearch.port }}
-        Verbose {{ collectd_settings.plugins.elasticsearch.verbose }}
-        Version "{{ collectd_settings.plugins.elasticsearch.version }}"
-        Cluster "{{ collectd_settings.plugins.elasticsearch.cluster }}"
-    </Module>
+  <Module "elasticsearch_collectd">
+    Verbose {{ collectd_settings.plugins.elasticsearch.verbose|lower }}
+    Host "{{ collectd_settings.plugins.elasticsearch.host }}"
+    Port {{ collectd_settings.plugins.elasticsearch.port }}
+    Cluster "{{ collectd_settings.plugins.elasticsearch.cluster }}"
+    Indexes {{ collectd_settings.plugins.elasticsearch.indexes }}
+    EnableIndexStats {{ collectd_settings.plugins.elasticsearch.index_stats|lower }}
+    EnableClusterHealth {{ collectd_settings.plugins.elasticsearch.cluster_health|lower }}
+    Interval {{ collectd_settings.plugins.elasticsearch.interval }}
+    IndexInterval {{ collectd_settings.plugins.elasticsearch.index_interval }}
+    DetailedMetrics {{ collectd_settings.plugins.elasticsearch.detailed_metrics|lower }}
+    ThreadPools {{ collectd_settings.plugins.elasticsearch.thread_pools }}
+    AdditionalMetrics {{ collectd_settings.plugins.elasticsearch.additional_metrics }}
+  </Module>
 </Plugin>

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -142,11 +142,19 @@
                 'Interactive': 'false'
             },
             'elasticsearch': {
-            	'host': 'localhost',
-            	'port': 9200,
-            	'cluster': 'elasticsearch',
-            	'version': '1.0',
-            	'verbose': 0
+              'host': 'localhost',
+              'port': 9200,
+              'additional_metrics': [""],
+              'cluster': 'elasticsearch',
+              'cluster_health': 'false',
+              'detailed_metrics': 'false',
+              'index_interval': 300,
+              'index_stats': 'false',
+              'indexes': ["_all"],
+              'interval': 10,
+              'gitrevision': 'master',
+              'thread_pools': ["search","index"],
+              'verbose': 'false'
             },
             'redis_info': {
             	'host': 'localhost',


### PR DESCRIPTION
It appears that the existing (ministryofsound) elasticsearch plugin may not be support beyond elasticsearch 1.0. However, the signalfx version seems to work rather well (albeit differently).

We're using this internally and it works rather well. Rather than install in the non existent and unmanaged collectd module path that is defined in map.jinja, I've installed it in the location described in the signalfx documentation.

Does this sound reasonable?
