### PR TITLE
Additions to java plugin + Introduce custom types.db

### DIFF
--- a/collectd/files/java.conf
+++ b/collectd/files/java.conf
@@ -10,6 +10,13 @@
 LoadPlugin java
 
 <Plugin "java">
+
+{%- if collectd_settings.plugins.java.jvmargs is defined  %}
+  {%- for jvmarg in collectd_settings.plugins.java.jvmargs %}
+      JVMARG "{{ jvmarg }}"
+  {%- endfor %}
+{%- endif %}
+
   LoadPlugin "org.collectd.java.GenericJMX"
 
   <Plugin "GenericJMX">

--- a/collectd/files/types.db
+++ b/collectd/files/types.db
@@ -1,0 +1,5 @@
+{%- from "collectd/map.jinja" import collectd_settings with context %}
+
+{%- for type in collectd_settings.types %}
+{{ type }}
+{%- endfor %}

--- a/collectd/types.sls
+++ b/collectd/types.sls
@@ -1,0 +1,14 @@
+{% from "collectd/map.jinja" import collectd_settings with context %}
+
+include:
+  - collectd
+
+{{ collectd_settings.plugindirconfig }}/types.db:
+  file.managed:
+    - source: salt://collectd/files/types.db
+    - user: {{ collectd_settings.user }}
+    - group: {{ collectd_settings.group }}
+    - mode: 644
+    - template: jinja
+    - watch_in:
+      - service: collectd-service

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,8 @@
 collectd:
   FQDNLookup: true
   TypesDB: ['/usr/share/collectd/types.db']
+  types:
+    - 'jmx_memory  value:GAUGE:0:U'
   plugins:
     default: [battery, cpu, entropy, load, memory, swap, users]
     curl_json:


### PR DESCRIPTION
- Support for JVMARG on the java plugin
- The java plugin needs type 'jmx_memory', hence adding support for custom types.