### PR TITLE
Fix multiple python modules in multiple pillar merging

### DIFF
--- a/collectd/files/python.conf
+++ b/collectd/files/python.conf
@@ -17,11 +17,11 @@
     Interactive "{{ collectd_settings.plugins.python.Interactive }}"
 
 {% if collectd_settings.plugins.python.get('modules', false) %}
-{%- for module in collectd_settings.plugins.python.modules %}
-    Import "{{ module.name }}"
-    {%- if module.variables is defined %}
-    <Module "{{ module.name }}">
-    {%- for key, value in module.variables | dictsort %}
+{%- for module, array in collectd_settings.plugins.python.modules.items() %}
+    Import "{{ module }}"
+    {%- if array['variables'] is defined %}
+    <Module "{{ module }}">
+    {%- for key, value in array['variables'].items() | sort %}
         {{ key }} {{ value }}
     {%- endfor %}
     </Module>

--- a/pillar.example
+++ b/pillar.example
@@ -171,7 +171,7 @@ collectd:
       LogTraces: true
       Interactive: false
       modules:
-        - name: module_name
+        module_name
           variables:
             var1: value1
             var2: value2


### PR DESCRIPTION
In case you have multiple pillars where multiple python modules are
defined - merging was not working - the last pillar was being used.
This fix provides that functionality.

example, depends on environment, you can have mesos master and slave
separated or not.
When you need both (dev) - proper merging was needed.

mesos-master.sls
```
collectd:
  plugins:
    python:
      modules:
        mesos-master:
          variables:
            FOO: "BAR_master"
```
mesos-slave.sls
```
collectd:
  plugins:
    python:
      modules:
        mesos-slave:
          variables:
            FOO: "BAR_slave"
```
results in /etc/collectd/plugins/python.conf:
```
...
    Import "mesos-master"
    <Module "mesos-master">
        FOO "BAR_master"
    </Module>
    Import "mesos-slave"
    <Module "mesos-slave">
        FOO "BAR_slave"
    </Module>
```