### PR TITLE
Fix types for python module

### DIFF
--- a/collectd/files/python.conf
+++ b/collectd/files/python.conf
@@ -13,8 +13,8 @@
 
 <Plugin python>
     ModulePath "{{ collectd_settings.moduledirconfig }}"
-    LogTraces "{{ collectd_settings.plugins.python.LogTraces }}"
-    Interactive "{{ collectd_settings.plugins.python.Interactive }}"
+    LogTraces {{ collectd_settings.plugins.python.LogTraces | lower }}
+    Interactive {{ collectd_settings.plugins.python.Interactive | lower }}
 
 {% if collectd_settings.plugins.python.get('modules', false) %}
 {%- for module in collectd_settings.plugins.python.modules %}


### PR DESCRIPTION
And again collectd requires boolean types for some parameters. From collectd 5.6 this will now result in fatal error.