### PR TITLE
Fix for sotore_rates in write_graphite plugin.

### DIFF
--- a/collectd/files/write_graphite.conf
+++ b/collectd/files/write_graphite.conf
@@ -23,7 +23,7 @@ LoadPlugin write_graphite
 {%- if collectd_settings.plugins.write_graphite.separateinstances is defined and collectd_settings.plugins.write_graphite.separateinstances %}
    SeparateInstances {{ collectd_settings.plugins.write_graphite.separateinstances|lower }}
 {%- endif %}
-{%- if collectd_settings.plugins.write_graphite.storerates is defined and collectd_settings.plugins.write_graphite.storerates %}
+{%- if collectd_settings.plugins.write_graphite.storerates is defined %}
    StoreRates {{ collectd_settings.plugins.write_graphite.storerates|lower }}
 {%- endif %}
 {%- if collectd_settings.plugins.write_graphite.alwaysappendds is defined and collectd_settings.plugins.write_graphite.alwaysappendds %}


### PR DESCRIPTION
The default for store_rates in the plugin code is true.  As you can see in the source: https://github.com/jssjr/collectd-write_graphite/commit/7e2b52c2c0ea7c5755d437740ae3e8ab59fdfb62

The construction of this if does not allow to disable it. If you set the value of the config variable to false the line won't be added to config and it will stay true. 

In short, it is not possible to disable StoreRates. This pull request tries to fix that. 