### PR TITLE
Added quotes around the process name for processes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,11 @@ This state is used to install OS packages collectd plugins depend on.
 
 Enables and configures the postgresql plugin. Needs refinement.
 
+``collectd.processes``
+----------------------
+
+Enables and configures the processes plugin
+
 ``collectd.powerdns``
 -----------------------
 

--- a/collectd/files/processes.conf
+++ b/collectd/files/processes.conf
@@ -1,5 +1,4 @@
-{%- from "collectd/map.jinja" import collectd_settings with context %}
-
+{%- from "collectd/map.jinja" import collectd_settings with context -%}
 #
 # DO NOT EDIT
 #
@@ -10,10 +9,10 @@
 LoadPlugin processes
 
 <Plugin "processes">
-{% for proc in collectd_settings.plugins.processes.Processes %}
-Process {{ proc }}
-{% endfor %}
-{% for procm in collectd_settings.plugins.processes.ProcessMatches %}
-ProcessMatch {{ procm }}
-{% endfor %}
+  {%- for proc in collectd_settings.plugins.processes.Processes %}
+  Process "{{ proc }}"
+  {%- endfor %}
+  {%- for procm in collectd_settings.plugins.processes.ProcessMatches %}
+  ProcessMatch {{ procm }}
+  {%- endfor %}
 </Plugin>


### PR DESCRIPTION
Missing quotes around process names, like `salt-minion`, can cause the
processes plugin to think more than one arguments was passed in.  The following
can be found in `syslog`:

```
processes plugin: `Process' expects exactly one string argument (got 2).
```

Also:
  - Added a `collectd.processes` section to the `README.md`.
  - Cleaned up the Jinja in `processes.conf` a bit.