### PR TITLE
Allowed setup more items in network configuration

### DIFF
--- a/collectd/files/network.conf
+++ b/collectd/files/network.conf
@@ -10,21 +10,26 @@
 LoadPlugin network
 
 <Plugin "network">
+{%- for item in collectd_settings.plugins.network %}
+        <{{ item.type | default('Server') }} "{{ item.host }}" "{{ item.port }}">
+          {%- if item.securitylevel is defined %}
+          SecurityLevel "{{ item.securitylevel }}"
+          {%- endif %}
+          {%- if item.username is defined and item.username and item.type == 'Server' %}
+          UserName "{{ item.username }}"
+          {%- endif %}
+          {%- if item.password is defined and item.password and item.type == 'Server' %}
+          Password "{{ item.password }}"
+          {%- endif %}
+          {%- if item.authfile is defined and item.authfile and item.type == 'Listen' %}
+          AuthFile "{{ item.authfile }}"
+          {%- endif %}
+          {%- if item.interface is defined %}
+          Interface "{{ item.interface }}"
+          {%- endif %}
+        </{{ item.type | default('Server') }}>
+{%- endfor %}
 #       # client setup:
-        <{{ collectd_settings.plugins.network.type | default('Server') }} "{{ collectd_settings.plugins.network.host }}" "{{ collectd_settings.plugins.network.port }}">
-          {%- if collectd_settings.plugins.network.securitylevel is defined%}
-          SecurityLevel "{{ collectd_settings.plugins.network.securitylevel }}"
-          {%- endif %}
-          {%- if collectd_settings.plugins.network.username is defined and collectd_settings.plugins.network.username and collectd_settings.plugins.network.type == 'Server' %}
-          UserName "{{ collectd_settings.plugins.network.username }}"
-          {%- endif %}
-          {%- if collectd_settings.plugins.network.password is defined and collectd_settings.plugins.network.password and collectd_settings.plugins.network.type == 'Server' %}
-          Password "{{ collectd_settings.plugins.network.password }}"
-          {%- endif %}
-          {%- if collectd_settings.plugins.network.authfile is defined and collectd_settings.plugins.network.authfile and collectd_settings.plugins.network.type == 'Listen' %}
-          AuthFile "{{ collectd_settings.plugins.network.authfile }}"
-          {%- endif %}
-        </{{ collectd_settings.plugins.network.type | default('Server') }}>
 #       <Server "239.192.74.66" "25826">
 #               SecurityLevel Encrypt
 #               Username "user"

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -94,7 +94,7 @@
             'mysql': {
                 'databases': []
             },
-            'network': {},
+            'network': [],
             'nginx': {
                 'url': 'http://localhost/check_status',
             },


### PR DESCRIPTION
Allows setup more (or both) Server/Listen items in network plugin configuration. It requires changing configuration in pillar to array. Added interface property for Server/Listen too.
Example pillar for network plugin:
```
  plugins:
    network:
      - host: '0.0.0.0'
        port: 12345
        type: Listen
      - host: '127.0.0.1'
        port: 12345
```