### PR TITLE
write_graphite plugin - allowed setup empty prefix

### DIFF
--- a/collectd/files/write_graphite.conf
+++ b/collectd/files/write_graphite.conf
@@ -12,7 +12,7 @@ LoadPlugin write_graphite
  <Carbon>
    Host "{{ collectd_settings.plugins.write_graphite.host }}"
    Port "{{ collectd_settings.plugins.write_graphite.port }}"
-   Prefix "{{ collectd_settings.plugins.write_graphite.prefix }}."
+   Prefix "{{ collectd_settings.plugins.write_graphite.prefix }}"
    Postfix "{{ collectd_settings.plugins.write_graphite.postfix }}"
 {%- if collectd_settings.plugins.write_graphite.escapecharacter is defined and collectd_settings.plugins.write_graphite.escapecharacter %}
    EscapeCharacter "{{ collectd_settings.plugins.write_graphite.escapecharacter }}"

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -127,7 +127,7 @@
             'write_graphite': {
                 'host': salt['grains.get']('fqdn'),
                 'port': 2003,
-                'prefix': 'collectd',
+                'prefix': 'collectd.',
                 'postfix': ''
             },
             'write_riemann': {

--- a/pillar.example
+++ b/pillar.example
@@ -134,7 +134,7 @@ collectd:
     write_graphite:
       host: graphite-host
       port: "2003"
-      prefix: "collectd"
+      prefix: "collectd."
       postfix: ""
       logsenderrors: false
       escapecharacter: "_"


### PR DESCRIPTION
Fixed config for write_graphite - allowed to setup empty prefix, which was not possible before. Requires update pillar and add ending "." to prefix config option.