### PR TITLE
df plugin - option to remove old ReportReserved config

### DIFF
--- a/collectd/files/df.conf
+++ b/collectd/files/df.conf
@@ -29,7 +29,6 @@ LoadPlugin df
 {%- endif %}
       IgnoreSelected "{{ collectd_settings.plugins.df.IgnoreSelected|lower }}"
       ReportByDevice "{{ collectd_settings.plugins.df.ReportByDevice|lower }}"
-      ReportReserved "{{ collectd_settings.plugins.df.ReportReserved|lower }}"
       ReportInodes "{{ collectd_settings.plugins.df.ReportInodes|lower }}"
       ValuesPercentage "{{ collectd_settings.plugins.df.ValuesPercentage|lower }}"
 </Plugin>

--- a/collectd/files/df.conf
+++ b/collectd/files/df.conf
@@ -29,6 +29,10 @@ LoadPlugin df
 {%- endif %}
       IgnoreSelected "{{ collectd_settings.plugins.df.IgnoreSelected|lower }}"
       ReportByDevice "{{ collectd_settings.plugins.df.ReportByDevice|lower }}"
+{%- if not collectd_settings.plugins.df.disable_report_reserved %}
+      # ReportReserved is only supported in old versions of collectd
+      ReportReserved "{{ collectd_settings.plugins.df.ReportReserved|lower }}"
+{%- endif %}
       ReportInodes "{{ collectd_settings.plugins.df.ReportInodes|lower }}"
       ValuesPercentage "{{ collectd_settings.plugins.df.ValuesPercentage|lower }}"
 </Plugin>

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -68,7 +68,6 @@
                 'Devices': [],
                 'IgnoreSelected': 'false',
                 'ReportByDevice': 'false',
-                'ReportReserved': 'false',
                 'ReportInodes': 'false',
                 'ValuesPercentage': 'false'
             },

--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -68,6 +68,8 @@
                 'Devices': [],
                 'IgnoreSelected': 'false',
                 'ReportByDevice': 'false',
+                'ReportReserved': 'false',
+                'disable_report_reserved': 'false',
                 'ReportInodes': 'false',
                 'ValuesPercentage': 'false'
             },

--- a/pillar.example
+++ b/pillar.example
@@ -103,7 +103,6 @@ collectd:
         - 'tmpfs'
       IgnoreSelected: false
       ReportByDevice:
-      ReportReserved:
       ReportInodes:
     ntpd:
       host: localhost


### PR DESCRIPTION
I expanded on PR #107 by @dosercz by adding the `disable_report_reserved` option. For existing users who are running old versions of collectd, they can upgrade to the latest version of this formula and won't have anything break.  But those of us with newer versions of collectd can set `disable_report_reserved` in Pillar. 