### PR TITLE
fixed object dump in collectd.python

### DIFF
--- a/collectd/files/python.conf
+++ b/collectd/files/python.conf
@@ -22,7 +22,13 @@
     {%- if array['variables'] is defined %}
     <Module "{{ module }}">
     {%- for key, value in array['variables'].items() | sort %}
-        {{ key }} {{ value }}
+        {%- if value is string or value is number %}
+          {{ key }} {{ value }}
+        {%- elif value is sequence %}
+          {{ key }} {{ value | json() }}
+        {%- else %}
+          {{ key }} {{ value }}
+        {%- endif %}
     {%- endfor %}
     </Module>
     {%- endif %}


### PR DESCRIPTION
Wrong dump python object with quotes (need double quotes)

### Actual behavior
```
    <Module "elasticsearch">
        AdditionalMetrics ['']
        ...
    </Module>
```

### Error
```
collectd[1581]: configfile: Cannot read file `/etc/collectd/plugins/python.conf'.
systemd[1]: Unit collectd.service entered failed state.
collectd[1581]: ['']
```

### Expected behavior
```
    <Module "elasticsearch">
        AdditionalMetrics [""]
        ...
    </Module>
```
