### PR TITLE
collectd service management

### DIFF
--- a/collectd/map.jinja
+++ b/collectd/map.jinja
@@ -44,6 +44,7 @@
         'CollectInternalStats': 'false',
         'FQDNLookup': 'false',
         'purge_plugindir': 'false',
+        'enable_service': true,
         'plugins': {
             'default': [
                 'battery',

--- a/collectd/service.sls
+++ b/collectd/service.sls
@@ -1,8 +1,12 @@
 {% from "collectd/map.jinja" import collectd_settings with context %}
 
 collectd-service:
+  {% if collectd_settings.enable_service %}
   service.running:
+  {% else %}
+  service.dead:
+  {% endif %}
     - name: {{ collectd_settings.service }}
-    - enable: True
+    - enable: {{ collectd_settings.enable_service }}
     - require:
       - pkg: {{ collectd_settings.pkg }}

--- a/pillar.example
+++ b/pillar.example
@@ -4,6 +4,7 @@ collectd:
   types:
     - 'jmx_memory  value:GAUGE:0:U'
   purge_plugindir: false        # if true, all non salt-managed files in plugindir will be removed
+  enable_service: true          # if false, service is not enabled and not started
   plugins:
     default: [battery, cpu, entropy, load, memory, swap, users]
     curl_json:


### PR DESCRIPTION
This PR adds a simple way to manage collectd service. Using `enable_service: false` in pillars allow to not start and not enable it. It defaults to true to not change default behaviour.

We use it in production because collectd+write_graphite floods the virtual console when it can't reach the graphite server. I think others can have the same need.
