### PR TITLE
some doc about TypesDB management

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -180,6 +180,11 @@ Enables and configures the syslog plugin.
 
 Enables and configures the tail plugin.
 
+``collectd.types``
+-------------------
+
+Manages a TypesDB file stored at `plugindirconfig`/types.db.
+
 ``collectd.curl_json``
 -------------------
 

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,8 @@
 collectd:
   FQDNLookup: true
-  TypesDB: ['/usr/share/collectd/types.db']
+  # To add new types to collectd, you need to reference the new file in TypesDB
+  TypesDB: ['/usr/share/collectd/types.db', '/etc/collectd/plugins/types.db']
+  # and add types below
   types:
     - 'jmx_memory  value:GAUGE:0:U'
   purge_plugindir: false        # if true, all non salt-managed files in plugindir will be removed


### PR DESCRIPTION
I discovered the needed code to add a type to TypesDB is already available in this formula, but without documentation.
This is an attempt to address it.
