### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/salt/default/pillar/collectd.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/pillar.example
+++ b/pillar.example
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 collectd:
   FQDNLookup: true
   # To add new types to collectd, you need to reference the new file in TypesDB
@@ -5,8 +8,10 @@ collectd:
   # and add types below
   types:
     - 'jmx_memory  value:GAUGE:0:U'
-  purge_plugindir: false        # if true, all non salt-managed files in plugindir will be removed
-  enable_service: true          # if false, service is not enabled and not started
+  # if true, all non salt-managed files in plugindir will be removed
+  purge_plugindir: false
+  # if false, service is not enabled and not started
+  enable_service: true
   plugins:
     default: [battery, cpu, entropy, load, memory, swap, users]
     curl_json:
@@ -71,7 +76,10 @@ collectd:
     dbi:
       queries:
         - name: mysql_user_connections
-          statement: SELECT user, count(*) as nof_connections FROM information_schema.processlist GROUP BY user
+          statement: >-
+            SELECT user, count(*) as nof_connections
+            FROM information_schema.processlist
+            GROUP BY user
           results:
             - type: gauge
               instancePrefix: mysql_user_connections
@@ -84,7 +92,9 @@ collectd:
             - mysql_user_connections
           driverOptions:
             - name: host
-              value: {{ salt['grains.get']('ip4_interfaces:eth1')[0] }}
+              value: 192.168.1.100
+              # Another method is to use `grains.get`:
+              # value: {{ salt['grains.get']('ip4_interfaces:eth1')[0] }}
             - name: username
               value: user
             - name: password
@@ -124,7 +134,7 @@ collectd:
     powerdns:
       socket: '/var/run/pdns.controlsocket'
     protocols:
-      IgnoreSelected: True
+      IgnoreSelected: true
     openldap:
       instances:
         - name: ldap
@@ -164,12 +174,12 @@ collectd:
     # defaults as of 20141103
     ping:
       hosts: ['google.com', 'yahoo.com']
-      #interval: 1.0
-      #timeout: 0.9
-      #ttl: 64
-      #sourceaddress: 10.0.1.1
-      #device: eth0
-      #maxmissed: -1
+      # interval: 1.0
+      # timeout: 0.9
+      # ttl: 64
+      # sourceaddress: 10.0.1.1
+      # device: eth0
+      # maxmissed: -1
     disk:
       matches: ['/^[hs]d[a-f][0-9]?$/']
     write_graphite:
@@ -185,7 +195,7 @@ collectd:
       storerates: true
       alwaysappendds: false
     processes:
-      Processes: 
+      Processes:
         - 'java'
         - 'python'
       ProcessMatches:
@@ -217,7 +227,7 @@ collectd:
       LogTraces: true
       Interactive: false
       modules:
-        module_name: # Replace module_name by your Python module
+        module_name:  # Replace module_name by your Python module
           variables:
             var1: value1
             var2: value2

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: collectd formula
 maintainer: SaltStack Formulas


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
collectd-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
pillar.example
  1:1       warning  missing document start "---"  (document-start)
  8:89      error    line too long (98 > 88 characters)  (line-length)
  74:89     error    line too long (111 > 88 characters)  (line-length)
  87:24     error    too many spaces inside braces  (braces)
  87:29     error    syntax error: expected ',' or '}', but got '['
  87:69     error    too many spaces inside braces  (braces)
  127:23    warning  truthy value should be one of [false, true]  (truthy)
  167:8     warning  missing starting space in comment  (comments)
  168:8     warning  missing starting space in comment  (comments)
  169:8     warning  missing starting space in comment  (comments)
  170:8     warning  missing starting space in comment  (comments)
  171:8     warning  missing starting space in comment  (comments)
  172:8     warning  missing starting space in comment  (comments)
  188:17    error    trailing spaces  (trailing-spaces)
  220:22    warning  too few spaces before comment  (comments)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.