### PR TITLE
ci(yamllint): add rule `empty-values` & use new `yaml-files` setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,9 @@ jobs:
       before_install: skip
       script:
         # Install and run `yamllint`
-        - pip install --user yamllint
-        # yamllint disable-line rule:line-length
-        - yamllint -s . .yamllint pillar.example test/salt/default/pillar/collectd.sls
+        # Need at least `v1.17.0` for the `yaml-files` setting
+        - pip install --user yamllint>=1.17.0
+        - yamllint -s .
         # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D

--- a/.yamllint
+++ b/.yamllint
@@ -6,10 +6,24 @@ extends: default
 
 # Files to ignore completely
 # 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+# 2. Any SLS files under directory `test/`, which are actually state files
 ignore: |
   node_modules/
+  test/**/states/**/*.sls
+
+yaml-files:
+  # Default settings
+  - '*.yaml'
+  - '*.yml'
+  - .yamllint
+  # SaltStack Formulas additional settings
+  - '*.example'
+  - test/**/*.sls
 
 rules:
+  empty-values:
+    forbid-in-block-mappings: true
+    forbid-in-flow-mappings: true
   line-length:
     # Increase from default of `80`
     # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)

--- a/pillar.example
+++ b/pillar.example
@@ -154,8 +154,8 @@ collectd:
         - 'ext4'
         - 'tmpfs'
       IgnoreSelected: false
-      ReportByDevice:
-      ReportInodes:
+      ReportByDevice: false
+      ReportInodes: false
     ntpd:
       host: localhost
       port: 123


### PR DESCRIPTION
* Semi-automated using https://github.com/myii/ssf-formula/pull/27
* Fix errors shown below:

```bash
collectd-formula$ yamllint -s .
./pillar.example
  157:22    error    empty value in block mapping  (empty-values)
  158:20    error    empty value in block mapping  (empty-values)
```